### PR TITLE
Add support for string

### DIFF
--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -14,10 +14,10 @@ var summary = BenchmarkRunner.Run<Benchmark>();
 [MemoryDiagnoser]
 public class Benchmark
 {
-	private static byte[] sample = [];
+	static byte[] sample = [];
 	static string sampleStr = "";
 
-	private static TokenType tokenType = TokenType.Words;
+	private static readonly TokenType tokenType = TokenType.Words;
 
 	[GlobalSetup]
 	public void Setup()
@@ -27,16 +27,25 @@ public class Benchmark
 	}
 
 	[Benchmark]
-	public void Tokenizer()
+	public void TokenizeBytes()
 	{
-		var tokens = new Tokenizer(sample, tokenType);
+		var tokens = Tokenizer.Create(sample, tokenType);
 		while (tokens.MoveNext())
 		{
 		}
 	}
 
-	//	[Benchmark]
-	public void StringInfo()
+	[Benchmark]
+	public void TokenizeString()
+	{
+		var tokens = Tokenizer.Create(sampleStr, tokenType);
+		while (tokens.MoveNext())
+		{
+		}
+	}
+
+	[Benchmark]
+	public void StringInfoGraphemes()
 	{
 		var enumerator = System.Globalization.StringInfo.GetTextElementEnumerator(sampleStr);
 		while (enumerator.MoveNext())
@@ -44,10 +53,10 @@ public class Benchmark
 		}
 	}
 
-	//	[Benchmark]
-	public void Graphemes()
+	[Benchmark]
+	public void TokenizerGraphemes()
 	{
-		var tokens = new Tokenizer(sample, TokenType.Graphemes);
+		var tokens = Tokenizer.Create(sample, TokenType.Graphemes);
 		while (tokens.MoveNext())
 		{
 		}
@@ -60,7 +69,7 @@ public class Benchmark
 		// warmup
 		for (var i = 0; i < runs; i++)
 		{
-			var tokens = new Tokenizer(sample, tokenType);
+			var tokens = Tokenizer.Create(sample, tokenType);
 			while (tokens.MoveNext())
 			{
 
@@ -73,7 +82,7 @@ public class Benchmark
 
 		for (var i = 0; i < runs; i++)
 		{
-			var tokens = new Tokenizer(sample, tokenType);
+			var tokens = Tokenizer.Create(sample, tokenType);
 			while (tokens.MoveNext())
 			{
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#
 
 ### Performance
 
-When tokenizing words, I get around 100MB/s on my Macbook Air M2. For typical text, that's probably around 25MM tokens/s, assuming tokens average 4 bytes. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
+When tokenizing words, I get around 100MB/s on my Macbook Air M2. For typical text, that's around 25MM tokens/s, assuming tokens average 4 bytes. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
 
-### Invalid UTF-8
+The tokenizer is implemented as a `ref struct`, so you should see zero allocations.
 
-The tokenizer expects valid UTF-8 bytes as input. That said, we [make an effort](https://github.com/clipperhouse/uax29.net/blob/main/Tests/Unicode.cs#L43-L68) to ensure that all bytes will be returned even if invalid, i.e. to be lossless in any case. Garbage in, garbage out.
+### Invalid inputs
+
+The tokenizer expects valid (decodable) UTF-8 bytes or UTF-16 chars as input. We [make an effort](https://github.com/clipperhouse/uax29.net/blob/main/Tests/Unicode.cs#L42-L67) to ensure that all bytes will be returned even if invalid, i.e. to be lossless in any case, though the resulting tokenization may not be useful. Garbage in, garbage out.
 
 ### Prior art
 
@@ -81,7 +83,7 @@ I previously implemented this for Go. This .Net version is something of a port o
 
 [StringInfo.GetTextElementEnumerator](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.stringinfo.gettextelementenumerator?view=net-8.0)
 
-The standard library has a similar enumerator for graphemes.
+The .Net Core standard library has a similar enumerator for graphemes.
 
 ### Other language implementations
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,32 @@ Any time our code operates on individual words, we are tokenizing. Often, we do 
 using uax29;
 using System.Text;
 
-// The API is bytes in and bytes out
-
 var example = "Here is some example text. 你好，世界.";
-var bytes = Encoding.UTF8.GetBytes(example);
 
-var tokens = new Tokenizer(bytes);
+// The tokenizer can take a string or a ReadOnlySpan<char>
+var tokens = Tokenizer.Create(example);
+
+// Iterate over the tokens		
 while (tokens.MoveNext())
 {
-	var s = Encoding.UTF8.GetString(tokens.Current);
-	Console.WriteLine(s);
+	// tokens.Current is a ReadOnlySpan<char>
+	// If you need it back as a string:
+	Console.WriteLine(tokens.Current.ToString());
 }
 
+
+// The tokenizer can also take raw UTF-8 bytes
+var utf8bytes = Encoding.UTF8.GetBytes(example);
+var tokens2 = Tokenizer.Create(utf8bytes);
+
+// Iterate over the tokens		
+while (tokens2.MoveNext())
+{
+	// tokens.Current is a ReadOnlySpan<byte> of UTF-8 bytes
+	// If you need it back as a string:
+	var s = Encoding.UTF8.GetString(tokens2.Current);
+	Console.WriteLine(s);
+}
 /*
 Here
  

--- a/Tests/Examples.cs
+++ b/Tests/Examples.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Runtime.InteropServices;
+using System.Text;
 using uax29;
 
 namespace Tests;
@@ -17,13 +18,29 @@ public class Examples
 	public void Readme()
 	{
 		var example = "Here is some example text. 你好，世界.";
-		var bytes = Encoding.UTF8.GetBytes(example);
 
-		var tokens = new Tokenizer(bytes);
+		// The tokenizer can take a string or ReadOnlySpan<char>
+		var tokens = Tokenizer.Create(example);
+
+		// Iterate over the tokens		
 		while (tokens.MoveNext())
 		{
-			// We return raw UTF-8 bytes
-			var s = Encoding.UTF8.GetString(tokens.Current);
+			// tokens.Current is a ReadOnlySpan<char>
+			// If you need it back as a string:
+			Console.WriteLine(tokens.Current.ToString());
+		}
+
+
+		// The tokenizer can also take raw UTF-8 bytes
+		var utf8bytes = Encoding.UTF8.GetBytes(example);
+		var tokens2 = Tokenizer.Create(utf8bytes);
+
+		// Iterate over the tokens		
+		while (tokens2.MoveNext())
+		{
+			// tokens.Current is a ReadOnlySpan<byte> of UTF-8 bytes
+			// If you need it back as a string:
+			var s = Encoding.UTF8.GetString(tokens2.Current);
 			Console.WriteLine(s);
 		}
 	}

--- a/Tests/TokenizerTests.cs
+++ b/Tests/TokenizerTests.cs
@@ -19,13 +19,13 @@ public class TestTokenizer
         var example = "Hello, how are you?";
         var bytes = Encoding.UTF8.GetBytes(example);
 
-        var tokens = new Tokenizer(bytes);
+        var tokens = Tokenizer.Create(example);
 
         var first = new List<string>();
         while (tokens.MoveNext())
         {
-            var s = Encoding.UTF8.GetString(tokens.Current);
-            first.Add(s);
+            // do something with tokens.Current
+            first.Add(tokens.Current.ToString());
         }
 
         Assert.That(first.Count > 1);   // just make sure it did the thing
@@ -35,8 +35,8 @@ public class TestTokenizer
         var second = new List<string>();
         while (tokens.MoveNext())
         {
-            var s = Encoding.UTF8.GetString(tokens.Current);
-            second.Add(s);
+            // do something with tokens.Current
+            second.Add(tokens.Current.ToString());
         }
 
         Assert.That(first.SequenceEqual(second));

--- a/Tests/Unicode.cs
+++ b/Tests/Unicode.cs
@@ -14,7 +14,7 @@ public class Unicode
 	{
 	}
 
-	static void TestTokenizer(Tokenizer tokens, UnicodeTest test)
+	static void TestTokenizer(Tokenizer<byte> tokens, UnicodeTest test)
 	{
 		var i = 0;
 		while (tokens.MoveNext())
@@ -34,7 +34,7 @@ public class Unicode
 	[Test, TestCaseSource(nameof(WordsTests))]
 	public void WordsTokenizer(UnicodeTest test)
 	{
-		var tokens = new Tokenizer(test.input);
+		var tokens = Tokenizer.Create(test.input);
 		TestTokenizer(tokens, test);
 	}
 
@@ -56,7 +56,7 @@ public class Unicode
 		foreach (TokenType tokenType in Enum.GetValues(typeof(TokenType)))
 		{
 			var results = new List<byte>();
-			var tokens = new Tokenizer(invalidUtf8Bytes, tokenType);
+			var tokens = Tokenizer.Create(invalidUtf8Bytes, tokenType);
 			while (tokens.MoveNext())
 			{
 				results.AddRange(tokens.Current);
@@ -70,7 +70,7 @@ public class Unicode
 	[Test, TestCaseSource(nameof(SentencesTests))]
 	public void SentencesTokenizer(UnicodeTest test)
 	{
-		var tokens = new Tokenizer(test.input, TokenType.Sentences);
+		var tokens = Tokenizer.Create(test.input, TokenType.Sentences);
 		TestTokenizer(tokens, test);
 	}
 
@@ -78,7 +78,7 @@ public class Unicode
 	[Test, TestCaseSource(nameof(GraphemesTests))]
 	public void GraphemesTokenizer(UnicodeTest test)
 	{
-		var tokens = new Tokenizer(test.input, TokenType.Graphemes);
+		var tokens = Tokenizer.Create(test.input, TokenType.Graphemes);
 		TestTokenizer(tokens, test);
 	}
 }

--- a/Tests/Unicode.cs
+++ b/Tests/Unicode.cs
@@ -14,28 +14,73 @@ public class Unicode
 	{
 	}
 
-	static void TestTokenizer(Tokenizer<byte> tokens, UnicodeTest test)
+	static void TestTokenizerBytes(Tokenizer<byte> tokens, UnicodeTest test)
 	{
 		var i = 0;
 		while (tokens.MoveNext())
 		{
 			var got = tokens.Current;
 			var expected = test.expected[i];
-			Assert.That(expected.AsSpan().SequenceEqual(got), $@"{test.comment}
-				input {test.input}
-				expected {expected}
-				got {got.ToArray()}
-				");
+			Assert.That(expected.AsSpan().SequenceEqual(got), $"{test.comment}");
+			i++;
+		}
+	}
+	static void TestTokenizerChars(Tokenizer<char> tokens, UnicodeTest test)
+	{
+		var i = 0;
+		while (tokens.MoveNext())
+		{
+			var got = tokens.Current;
+			var expected = test.expected[i];
+			var s = Encoding.UTF8.GetString(expected).AsSpan();
+			Assert.That(s.SequenceEqual(got), $"{test.comment}");
 			i++;
 		}
 	}
 
 	static readonly UnicodeTest[] WordsTests = UnicodeTests.Words;
 	[Test, TestCaseSource(nameof(WordsTests))]
-	public void WordsTokenizer(UnicodeTest test)
+	public void WordsBytes(UnicodeTest test)
 	{
 		var tokens = Tokenizer.Create(test.input);
-		TestTokenizer(tokens, test);
+		TestTokenizerBytes(tokens, test);
+	}
+	[Test, TestCaseSource(nameof(WordsTests))]
+	public void WordsString(UnicodeTest test)
+	{
+		var s = Encoding.UTF8.GetString(test.input);
+		var tokens = Tokenizer.Create(s);
+		TestTokenizerChars(tokens, test);
+	}
+
+	static readonly UnicodeTest[] SentencesTests = UnicodeTests.Sentences;
+	[Test, TestCaseSource(nameof(SentencesTests))]
+	public void SentencesBytes(UnicodeTest test)
+	{
+		var tokens = Tokenizer.Create(test.input, TokenType.Sentences);
+		TestTokenizerBytes(tokens, test);
+	}
+	[Test, TestCaseSource(nameof(SentencesTests))]
+	public void SentencesString(UnicodeTest test)
+	{
+		var s = Encoding.UTF8.GetString(test.input);
+		var tokens = Tokenizer.Create(s, TokenType.Sentences);
+		TestTokenizerChars(tokens, test);
+	}
+
+	static readonly UnicodeTest[] GraphemesTests = UnicodeTests.Graphemes;
+	[Test, TestCaseSource(nameof(GraphemesTests))]
+	public void GraphemesBytes(UnicodeTest test)
+	{
+		var tokens = Tokenizer.Create(test.input, TokenType.Graphemes);
+		TestTokenizerBytes(tokens, test);
+	}
+	[Test, TestCaseSource(nameof(GraphemesTests))]
+	public void GraphemesString(UnicodeTest test)
+	{
+		var s = Encoding.UTF8.GetString(test.input);
+		var tokens = Tokenizer.Create(s, TokenType.Graphemes);
+		TestTokenizerChars(tokens, test);
 	}
 
 	[Test]
@@ -64,21 +109,5 @@ public class Unicode
 
 			Assert.That(results.SequenceEqual(invalidUtf8Bytes));
 		}
-	}
-
-	static readonly UnicodeTest[] SentencesTests = UnicodeTests.Sentences;
-	[Test, TestCaseSource(nameof(SentencesTests))]
-	public void SentencesTokenizer(UnicodeTest test)
-	{
-		var tokens = Tokenizer.Create(test.input, TokenType.Sentences);
-		TestTokenizer(tokens, test);
-	}
-
-	static readonly UnicodeTest[] GraphemesTests = UnicodeTests.Graphemes;
-	[Test, TestCaseSource(nameof(GraphemesTests))]
-	public void GraphemesTokenizer(UnicodeTest test)
-	{
-		var tokens = Tokenizer.Create(test.input, TokenType.Graphemes);
-		TestTokenizer(tokens, test);
 	}
 }

--- a/Tests/Unicode.cs
+++ b/Tests/Unicode.cs
@@ -111,8 +111,8 @@ public class Unicode
 		}
 
 		char[] invalidChars = [
+			'\uDC00', // Low surrogate without a high surrogate
 			'\uD800', // High surrogate without a low surrogate
-            '\uDC00', // Low surrogate without a high surrogate
             '\uFFFF', // Invalid Unicode character
             '\uD800', '\uD800', // Two high surrogates
             '\uDC00', '\uDC00', // Two low surrogates

--- a/Tests/Unicode.cs
+++ b/Tests/Unicode.cs
@@ -84,7 +84,7 @@ public class Unicode
 	}
 
 	[Test]
-	public void InvalidUTF8()
+	public void Invalid()
 	{
 		byte[] invalidUtf8Bytes =
 		[
@@ -110,17 +110,24 @@ public class Unicode
 			Assert.That(results.SequenceEqual(invalidUtf8Bytes));
 		}
 
+		char[] invalidChars = [
+			'\uD800', // High surrogate without a low surrogate
+            '\uDC00', // Low surrogate without a high surrogate
+            '\uFFFF', // Invalid Unicode character
+            '\uD800', '\uD800', // Two high surrogates
+            '\uDC00', '\uDC00', // Two low surrogates
+		];
+
 		foreach (TokenType tokenType in Enum.GetValues(typeof(TokenType)))
 		{
 			var results = new List<char>();
-			var invalidString = Encoding.UTF8.GetString(invalidUtf8Bytes);
-			var tokens = Tokenizer.Create(invalidString, tokenType);
+			var tokens = Tokenizer.Create(invalidChars, tokenType);
 			while (tokens.MoveNext())
 			{
 				results.AddRange(tokens.Current);
 			}
 
-			Assert.That(results.SequenceEqual(invalidString));
+			Assert.That(results.SequenceEqual(invalidChars));
 		}
 	}
 }

--- a/Tests/Unicode.cs
+++ b/Tests/Unicode.cs
@@ -109,5 +109,18 @@ public class Unicode
 
 			Assert.That(results.SequenceEqual(invalidUtf8Bytes));
 		}
+
+		foreach (TokenType tokenType in Enum.GetValues(typeof(TokenType)))
+		{
+			var results = new List<char>();
+			var invalidString = Encoding.UTF8.GetString(invalidUtf8Bytes);
+			var tokens = Tokenizer.Create(invalidString, tokenType);
+			while (tokens.MoveNext())
+			{
+				results.AddRange(tokens.Current);
+			}
+
+			Assert.That(results.SequenceEqual(invalidString));
+		}
 	}
 }

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -9,7 +9,8 @@ using Property = uint;
 
 internal static partial class Graphemes
 {
-    internal static readonly Split Split = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeFromUtf16).Split;
 
     internal class Splitter<TSpan> : SplitterBase<TSpan>
     {

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -9,17 +9,17 @@ using Property = uint;
 
 internal static partial class Graphemes
 {
-    internal static readonly Split Split = new Splitter(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split Split = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
 
-    internal class Splitter : SplitterBase
+    internal class Splitter<TSpan> : SplitterBase<TSpan>
     {
-        internal Splitter(Decoder decodeFirstRune, Decoder decodeLastRune) :
+        internal Splitter(Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune) :
             base(Graphemes.Dict, Ignore, decodeFirstRune, decodeLastRune)
         { }
 
         new const Property Ignore = Extend;
 
-        public override int Split(ReadOnlySpan<byte> input, bool atEOF = true)
+        public override int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
         {
             if (input.Length == 0)
             {

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -10,7 +10,7 @@ using Property = uint;
 internal static partial class Graphemes
 {
     internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
-    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeFromUtf16).Split;
+    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeLastFromUtf16).Split;
 
     internal class Splitter<TSpan> : SplitterBase<TSpan>
     {

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -97,7 +97,7 @@ internal static partial class Graphemes
                 }
 
                 // https://unicode.org/reports/tr29/#GB3
-                if (current.Iss(LF) && last.Iss(CR))
+                if (current.Is(LF) && last.Is(CR))
                 {
                     pos += w;
                     continue;
@@ -105,55 +105,55 @@ internal static partial class Graphemes
 
                 // https://unicode.org/reports/tr29/#GB4
                 // https://unicode.org/reports/tr29/#GB5
-                if ((current | last).Iss(Control | CR | LF))
+                if ((current | last).Is(Control | CR | LF))
                 {
                     break;
                 }
 
                 // https://unicode.org/reports/tr29/#GB6
-                if (current.Iss(L | V | LV | LVT) && last.Iss(L))
+                if (current.Is(L | V | LV | LVT) && last.Is(L))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#GB7
-                if (current.Iss(V | T) && last.Iss(LV | V))
+                if (current.Is(V | T) && last.Is(LV | V))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#GB8
-                if (current.Iss(T) && last.Iss(LVT | T))
+                if (current.Is(T) && last.Is(LVT | T))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#GB9
-                if (current.Iss(Extend | ZWJ))
+                if (current.Is(Extend | ZWJ))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#GB9a
-                if (current.Iss(SpacingMark))
+                if (current.Is(SpacingMark))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#GB9b
-                if (last.Iss(Prepend))
+                if (last.Is(Prepend))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#GB11
-                if (current.Iss(Extended_Pictographic) && last.Iss(ZWJ) && Previous(Extended_Pictographic, input[..(pos - lastWidth)]))
+                if (current.Is(Extended_Pictographic) && last.Is(ZWJ) && Previous(Extended_Pictographic, input[..(pos - lastWidth)]))
                 {
                     pos += w;
                     continue;
@@ -162,7 +162,7 @@ internal static partial class Graphemes
 
                 // https://unicode.org/reports/tr29/#GB12 and
                 // https://unicode.org/reports/tr29/#GB13
-                if ((current & last).Iss(Regional_Indicator))
+                if ((current & last).Is(Regional_Indicator))
                 {
                     var i = pos;
                     var count = 0;
@@ -184,7 +184,7 @@ internal static partial class Graphemes
 
                         var lookup = Dict.Lookup(rune2.Value);
 
-                        if (!lookup.Iss(Regional_Indicator))
+                        if (!lookup.Is(Regional_Indicator))
                         {
                             // It's GB13
                             break;

--- a/uax29/README.md
+++ b/uax29/README.md
@@ -67,11 +67,13 @@ We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#
 
 ### Performance
 
-When tokenizing words, I get around 100MB/s on my Macbook Air M2. For typical text, that's probably around 25MM tokens/s, assuming tokens average 4 bytes. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
+When tokenizing words, I get around 100MB/s on my Macbook Air M2. For typical text, that's around 25MM tokens/s, assuming tokens average 4 bytes. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
 
-### Invalid UTF-8
+The tokenizer is implemented as a `ref struct`, so you should see zero allocations.
 
-The tokenizer expects valid UTF-8 bytes as input. That said, we [make an effort](https://github.com/clipperhouse/uax29.net/blob/main/Tests/Unicode.cs#L43-L68) to ensure that all bytes will be returned even if invalid, i.e. to be lossless in any case. Garbage in, garbage out.
+### Invalid inputs
+
+The tokenizer expects valid (decodable) UTF-8 bytes or UTF-16 chars as input. We [make an effort](https://github.com/clipperhouse/uax29.net/blob/main/Tests/Unicode.cs#L42-L67) to ensure that all bytes will be returned even if invalid, i.e. to be lossless in any case, though the resulting tokenization may not be useful. Garbage in, garbage out.
 
 ### Prior art
 
@@ -81,7 +83,7 @@ I previously implemented this for Go. This .Net version is something of a port o
 
 [StringInfo.GetTextElementEnumerator](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.stringinfo.gettextelementenumerator?view=net-8.0)
 
-The standard library has a similar enumerator for graphemes.
+The .Net Core standard library has a similar enumerator for graphemes.
 
 ### Other language implementations
 

--- a/uax29/README.md
+++ b/uax29/README.md
@@ -10,18 +10,32 @@ Any time our code operates on individual words, we are tokenizing. Often, we do 
 using uax29;
 using System.Text;
 
-// The API is bytes in and bytes out
-
 var example = "Here is some example text. 你好，世界.";
-var bytes = Encoding.UTF8.GetBytes(example);
 
-var tokens = new Tokenizer(bytes);
+// The tokenizer can take a string or a ReadOnlySpan<char>
+var tokens = Tokenizer.Create(example);
+
+// Iterate over the tokens		
 while (tokens.MoveNext())
 {
-	var s = Encoding.UTF8.GetString(tokens.Current);
-	Console.WriteLine(s);
+	// tokens.Current is a ReadOnlySpan<char>
+	// If you need it back as a string:
+	Console.WriteLine(tokens.Current.ToString());
 }
 
+
+// The tokenizer can also take raw UTF-8 bytes
+var utf8bytes = Encoding.UTF8.GetBytes(example);
+var tokens2 = Tokenizer.Create(utf8bytes);
+
+// Iterate over the tokens		
+while (tokens2.MoveNext())
+{
+	// tokens.Current is a ReadOnlySpan<byte> of UTF-8 bytes
+	// If you need it back as a string:
+	var s = Encoding.UTF8.GetString(tokens2.Current);
+	Console.WriteLine(s);
+}
 /*
 Here
  

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -8,7 +8,8 @@ using Property = uint;
 
 internal static partial class Sentences
 {
-    internal static readonly Split Split = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeFromUtf16).Split;
 
     internal class Splitter<TSpan> : SplitterBase<TSpan>
     {
@@ -62,6 +63,7 @@ internal static partial class Sentences
                 var last = current;
 
                 var status = DecodeFirstRune(input[pos..], out Rune rune, out w);
+
                 if (status != OperationStatus.Done)
                 {
                     // Garbage in, garbage out

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -8,11 +8,11 @@ using Property = uint;
 
 internal static partial class Sentences
 {
-    internal static readonly Split Split = new Splitter(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split Split = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
 
-    internal class Splitter : SplitterBase
+    internal class Splitter<TSpan> : SplitterBase<TSpan>
     {
-        internal Splitter(Decoder decodeFirstRune, Decoder decodeLastRune) :
+        internal Splitter(Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune) :
             base(Sentences.Dict, Ignore, decodeFirstRune, decodeLastRune)
         { }
 
@@ -20,7 +20,7 @@ internal static partial class Sentences
         const Property ParaSep = Sep | CR | LF;
         new const Property Ignore = Extend | Format;
 
-        public override int Split(ReadOnlySpan<byte> input, bool atEOF = true)
+        public override int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
         {
             if (input.Length == 0)
             {

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -99,20 +99,20 @@ internal static partial class Sentences
                 }
 
                 // https://unicode.org/reports/tr29/#SB3
-                if (current.Iss(LF) && last.Iss(CR))
+                if (current.Is(LF) && last.Is(CR))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#SB4
-                if (last.Iss(ParaSep))
+                if (last.Is(ParaSep))
                 {
                     break;
                 }
 
                 // https://unicode.org/reports/tr29/#SB5
-                if (current.Iss(Extend | Format))
+                if (current.Is(Extend | Format))
                 {
                     pos += w;
                     continue;
@@ -123,7 +123,7 @@ internal static partial class Sentences
                 // The previous/subsequent methods are shorthand for "seek a property but skip over Extend & Format on the way"
 
                 // Optimization: determine if SB6 can possibly apply
-                var maybeSB6 = (current.Iss(Numeric) && last.Iss(ATerm | Ignore));
+                var maybeSB6 = (current.Is(Numeric) && last.Is(ATerm | Ignore));
 
                 // https://unicode.org/reports/tr29/#SB6
                 if (maybeSB6)
@@ -136,7 +136,7 @@ internal static partial class Sentences
                 }
 
                 // Optimization: determine if SB7 can possibly apply
-                var maybeSB7 = current.Iss(Upper) && last.Iss(ATerm | Ignore);
+                var maybeSB7 = current.Is(Upper) && last.Is(ATerm | Ignore);
 
                 // https://unicode.org/reports/tr29/#SB7
                 if (maybeSB7)
@@ -150,7 +150,7 @@ internal static partial class Sentences
                 }
 
                 // Optimization: determine if SB8 can possibly apply
-                var maybeSB8 = last.Iss(ATerm | Close | Sp | Ignore);
+                var maybeSB8 = last.Is(ATerm | Close | Sp | Ignore);
 
                 // https://unicode.org/reports/tr29/#SB8
                 if (maybeSB8)
@@ -181,7 +181,7 @@ internal static partial class Sentences
 
                         var lookup = Dict.Lookup(rune2.Value);
 
-                        if (lookup.Iss(OLetter | Upper | Lower | ParaSep | SATerm))
+                        if (lookup.Is(OLetter | Upper | Lower | ParaSep | SATerm))
                         {
                             break;
                         }
@@ -228,7 +228,7 @@ internal static partial class Sentences
                 }
 
                 // Optimization: determine if SB8a can possibly apply
-                var maybeSB8a = current.Iss(SContinue | SATerm) && last.Iss(SATerm | Close | Sp | Ignore);
+                var maybeSB8a = current.Is(SContinue | SATerm) && last.Is(SATerm | Close | Sp | Ignore);
 
                 // https://unicode.org/reports/tr29/#SB8a
                 if (maybeSB8a)
@@ -269,7 +269,7 @@ internal static partial class Sentences
                 }
 
                 // Optimization: determine if SB9 can possibly apply
-                var maybeSB9 = current.Iss(Close | Sp | ParaSep) && last.Iss(SATerm | Close | Ignore);
+                var maybeSB9 = current.Is(Close | Sp | ParaSep) && last.Is(SATerm | Close | Ignore);
 
                 // https://unicode.org/reports/tr29/#SB9
                 if (maybeSB9)
@@ -298,7 +298,7 @@ internal static partial class Sentences
                 }
 
                 // Optimization: determine if SB10 can possibly apply
-                var maybeSB10 = current.Iss(Sp | ParaSep) && last.Iss(SATerm | Close | Sp | Ignore);
+                var maybeSB10 = current.Is(Sp | ParaSep) && last.Is(SATerm | Close | Sp | Ignore);
 
                 // https://unicode.org/reports/tr29/#SB10
                 if (maybeSB10)
@@ -339,7 +339,7 @@ internal static partial class Sentences
                 }
 
                 // Optimization: determine if SB11 can possibly apply
-                var maybeSB11 = last.Iss(SATerm | Close | Sp | ParaSep | Ignore);
+                var maybeSB11 = last.Is(SATerm | Close | Sp | ParaSep | Ignore);
 
                 // https://unicode.org/reports/tr29/#SB11
                 if (maybeSB11)

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -9,7 +9,7 @@ using Property = uint;
 internal static partial class Sentences
 {
     internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
-    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeFromUtf16).Split;
+    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeLastFromUtf16).Split;
 
     internal class Splitter<TSpan> : SplitterBase<TSpan>
     {

--- a/uax29/Splitter.cs
+++ b/uax29/Splitter.cs
@@ -94,12 +94,12 @@ internal abstract class SplitterBase<TSpan>
     /// <param name="property">Property to attempt to find</param>
     /// <param name="input">Data in which to seek</param>
     /// <returns>True if found, otherwise false</returns>
-    internal bool Subsequent(Property property, ReadOnlySpan<TSpan> data)
+    internal bool Subsequent(Property property, ReadOnlySpan<TSpan> input)
     {
         var i = 0;
-        while (i < data.Length)
+        while (i < input.Length)
         {
-            var status = DecodeFirstRune(data[i..], out Rune rune, out int w);
+            var status = DecodeFirstRune(input[i..], out Rune rune, out int w);
             if (status != OperationStatus.Done)
             {
                 // Garbage in, garbage out
@@ -133,6 +133,12 @@ internal abstract class SplitterBase<TSpan>
 
 internal static class Extensions
 {
+    /// <summary>
+    /// Determines whether two properties (bitstrings) match, i.e. intersect, i.e. share at least one bit.
+    /// </summary>
+    /// <param name="lookup">One property to test against...</param>
+    /// <param name="properties">...the other</param>
+    /// <returns>True if the two properties share a bit, i.e. Unicode category.</returns>
     internal static bool Is(this Property lookup, Property properties)
     {
         return (lookup & properties) != 0;

--- a/uax29/Splitter.cs
+++ b/uax29/Splitter.cs
@@ -60,12 +60,12 @@ internal abstract class SplitterBase<TSpan>
             i -= w;
             var lookup = Dict.Lookup(rune.Value);
 
-            if (lookup.Iss(Ignore))
+            if (lookup.Is(Ignore))
             {
                 continue;
             }
 
-            if (lookup.Iss(property))
+            if (lookup.Is(property))
             {
                 return i;
             }
@@ -112,13 +112,13 @@ internal abstract class SplitterBase<TSpan>
 
             var lookup = Dict.Lookup(rune.Value);
 
-            if (lookup.Iss(Ignore))
+            if (lookup.Is(Ignore))
             {
                 i += w;
                 continue;
             }
 
-            if (lookup.Iss(property))
+            if (lookup.Is(property))
             {
                 return true;
             }
@@ -133,7 +133,7 @@ internal abstract class SplitterBase<TSpan>
 
 internal static class Extensions
 {
-    internal static bool Iss(this Property lookup, Property properties)
+    internal static bool Is(this Property lookup, Property properties)
     {
         return (lookup & properties) != 0;
     }

--- a/uax29/Splitter.cs
+++ b/uax29/Splitter.cs
@@ -6,16 +6,16 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
-internal delegate OperationStatus Decoder(ReadOnlySpan<byte> input, out Rune result, out int consumed);
+internal delegate OperationStatus Decoder<TSpan>(ReadOnlySpan<TSpan> input, out Rune result, out int consumed);
 
-internal abstract class SplitterBase
+internal abstract class SplitterBase<TSpan>
 {
     readonly internal Dict Dict;
     readonly internal Property Ignore;
-    readonly internal Decoder DecodeFirstRune;
-    readonly internal Decoder DecodeLastRune;
+    readonly internal Decoder<TSpan> DecodeFirstRune;
+    readonly internal Decoder<TSpan> DecodeLastRune;
 
-    public SplitterBase(Dict dict, Property ignore, Decoder decodeFirstRune, Decoder decodeLastRune)
+    public SplitterBase(Dict dict, Property ignore, Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune)
     {
         this.Dict = dict;
         this.Ignore = ignore;
@@ -32,7 +32,7 @@ internal abstract class SplitterBase
     /// (Always true in the current implementation, we may implement streaming in the future.)
     /// </param>
     /// <returns></returns>
-    public abstract int Split(ReadOnlySpan<byte> input, bool atEOF);
+    public abstract int Split(ReadOnlySpan<TSpan> input, bool atEOF);
 
     /// <summary>
     /// Seek backward until it hits a rune which matches property.
@@ -40,7 +40,7 @@ internal abstract class SplitterBase
     /// <param name="property">Property to attempt to find</param>
     /// <param name="input">Data in which to seek</param>
     /// <returns>The index if found, or -1 if not</returns>
-    internal int PreviousIndex(Property property, ReadOnlySpan<byte> input)
+    internal int PreviousIndex(Property property, ReadOnlySpan<TSpan> input)
     {
         // Start at the end of the buffer and move backwards
         var i = input.Length;
@@ -83,7 +83,7 @@ internal abstract class SplitterBase
     /// <param name="property">Property to attempt to find</param>
     /// <param name="input">Data in which to seek</param>
     /// <returns>True if found, otherwise false</returns>
-    internal bool Previous(Property property, ReadOnlySpan<byte> input)
+    internal bool Previous(Property property, ReadOnlySpan<TSpan> input)
     {
         return PreviousIndex(property, input) != -1;
     }
@@ -94,7 +94,7 @@ internal abstract class SplitterBase
     /// <param name="property">Property to attempt to find</param>
     /// <param name="input">Data in which to seek</param>
     /// <returns>True if found, otherwise false</returns>
-    internal bool Subsequent(Property property, ReadOnlySpan<byte> data)
+    internal bool Subsequent(Property property, ReadOnlySpan<TSpan> data)
     {
         var i = 0;
         while (i < data.Length)

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -57,7 +57,7 @@ public static class Tokenizer
 
 /// <summary>
 /// Tokenizer splits strings or UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
-/// Use MoveNext to iterate, and Current to retrive the current token (i.e. word, grapheme or sentence).
+/// Use <see cref="Tokenizer{T}.MoveNext"/> to iterate, and <see cref="Tokenizer{T}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
 /// </summary>
 public ref struct Tokenizer<T> where T : struct
 {
@@ -69,9 +69,9 @@ public ref struct Tokenizer<T> where T : struct
 	int end = 0;
 
 	/// <summary>
-	/// Tokenizer splits strings (bytes) as words, sentences or graphemes, per the Unicode UAX #29 spec.
+	/// Tokenizer splits strings (or UTF-8 bytes) as words, sentences or graphemes, per the Unicode UAX #29 spec.
 	/// </summary>
-	/// <param name="input">A UTF-8 byte string</param>
+	/// <param name="input">A string, or UTF-8 byte array.</param>
 	/// <param name="tokenType">Choose to split words, graphemes or sentences. Default is words.</param>
 	internal Tokenizer(ReadOnlySpan<T> input, TokenType tokenType = TokenType.Words)
 	{
@@ -107,7 +107,7 @@ public ref struct Tokenizer<T> where T : struct
 	}
 
 	/// <summary>
-	/// Move to the next token. Returns false when no more tokens (typically EOF). Use Current to retrieve the token.
+	/// Move to the next token. Use <see cref="Current"/> to retrieve the token.
 	/// </summary>
 	/// <returns>Whether there are any more tokens. False typically means EOF.</returns>
 	public bool MoveNext()
@@ -130,7 +130,9 @@ public ref struct Tokenizer<T> where T : struct
 	}
 
 	/// <summary>
-	/// The current token (word, grapheme or sentence) as UTF-8 bytes. Use Encoding.UTF8 to get a string.
+	/// The current token (word, grapheme or sentence).
+	/// If the input was a string, <see cref="Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
+	/// If the input was UTF-8 bytes, <see cref="Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
 	/// </summary>
 	public readonly ReadOnlySpan<T> Current
 	{
@@ -141,7 +143,7 @@ public ref struct Tokenizer<T> where T : struct
 	}
 
 	/// <summary>
-	/// Resets the tokenizer to the first rune.
+	/// Resets the tokenizer back to the first token.
 	/// </summary>
 	public void Reset()
 	{

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -1,23 +1,69 @@
 namespace uax29;
 
 using System.ComponentModel;
+using System.Globalization;
 
 public enum TokenType
 {
 	Words, Graphemes, Sentences
 }
 
-public delegate int Split(ReadOnlySpan<byte> input, bool atEOF = true);
+public delegate int Split<T>(ReadOnlySpan<T> input, bool atEOF = true);
+
+public static class Tokenizer
+{
+	/// <summary>
+	/// Create a tokenizer for a string, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="input">The string to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="Tokenizer{T}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{T}.Current"/>.
+	/// <see cref="Tokenizer{T}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
+	/// </returns>
+	public static Tokenizer<char> Create(string input, TokenType tokenType = TokenType.Words)
+	{
+		return new Tokenizer<char>(input.AsSpan(), tokenType);
+	}
+
+	/// <summary>
+	/// Create a tokenizer for a <see cref="ReadOnlySpan"/> (or array) of UTF-8 encoded bytes, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="input">The UTF-8 bytes to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="Tokenizer{T}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{T}.Current"/>.
+	/// <see cref="Tokenizer{T}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
+	/// </returns>
+	public static Tokenizer<byte> Create(ReadOnlySpan<byte> input, TokenType tokenType = TokenType.Words)
+	{
+		return new Tokenizer<byte>(input, tokenType);
+	}
+
+	/// <summary>
+	/// Create a tokenizer for a <see cref="ReadOnlySpan"/> of <see cref="char"/>, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="input">The string to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="Tokenizer{T}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{T}.Current"/>.
+	/// <see cref="Tokenizer{T}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
+	/// </returns>
+	public static Tokenizer<char> Create(ReadOnlySpan<char> input, TokenType tokenType = TokenType.Words)
+	{
+		return new Tokenizer<char>(input, tokenType);
+	}
+}
 
 /// <summary>
-/// Tokenizer splits strings (bytes) as words, sentences or graphemes, per the Unicode UAX #29 spec.
-/// It accepts UTF-8 bytes, an returns an iterator.
+/// Tokenizer splits strings or UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
+/// Use MoveNext to iterate, and Current to retrive the current token (i.e. word, grapheme or sentence).
 /// </summary>
-public ref struct Tokenizer
+public ref struct Tokenizer<T> where T : struct
 {
-	readonly ReadOnlySpan<byte> input;
-	readonly Split Split;
-	readonly TokenType TokenType;
+	readonly ReadOnlySpan<T> input;
+	readonly Split<T> Split;
+	public readonly TokenType TokenType;
 
 	int start = 0;
 	int end = 0;
@@ -27,17 +73,37 @@ public ref struct Tokenizer
 	/// </summary>
 	/// <param name="input">A UTF-8 byte string</param>
 	/// <param name="tokenType">Choose to split words, graphemes or sentences. Default is words.</param>
-	public Tokenizer(ReadOnlySpan<byte> input, TokenType tokenType = TokenType.Words)
+	internal Tokenizer(ReadOnlySpan<T> input, TokenType tokenType = TokenType.Words)
 	{
 		this.input = input;
 		this.TokenType = tokenType;
-		this.Split = tokenType switch
+
+		Type type = typeof(T);
+		if (type == typeof(byte))
 		{
-			TokenType.Words => Words.Split,
-			TokenType.Graphemes => Graphemes.Split,
-			TokenType.Sentences => Sentences.Split,
-			_ => throw new InvalidEnumArgumentException(nameof(tokenType), (int)tokenType, typeof(TokenType))
-		};
+			this.Split = tokenType switch
+			{
+				TokenType.Words => Words.SplitUtf8Bytes as Split<T>,
+				TokenType.Graphemes => Graphemes.SplitUtf8Bytes as Split<T>,
+				TokenType.Sentences => Sentences.SplitUtf8Bytes as Split<T>,
+				// I wish T were inferrable simply by choice of the above generic delegates!
+				_ => throw new InvalidEnumArgumentException(nameof(tokenType), (int)tokenType, typeof(TokenType))
+			} ?? throw new NotImplementedException();
+		}
+		else if (type == typeof(char))
+		{
+			this.Split = tokenType switch
+			{
+				TokenType.Words => Words.SplitChars as Split<T>,
+				TokenType.Graphemes => Graphemes.SplitChars as Split<T>,
+				TokenType.Sentences => Sentences.SplitChars as Split<T>,
+				_ => throw new InvalidEnumArgumentException(nameof(tokenType), (int)tokenType, typeof(TokenType))
+			} ?? throw new NotImplementedException();
+		}
+		else
+		{
+			throw new NotImplementedException();
+		}
 	}
 
 	/// <summary>
@@ -66,7 +132,7 @@ public ref struct Tokenizer
 	/// <summary>
 	/// The current token (word, grapheme or sentence) as UTF-8 bytes. Use Encoding.UTF8 to get a string.
 	/// </summary>
-	public readonly ReadOnlySpan<byte> Current
+	public readonly ReadOnlySpan<T> Current
 	{
 		get
 		{

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -76,11 +76,17 @@ public ref struct Tokenizer<TSpan> where TSpan : struct
 	{
 		this.input = input;
 		this.TokenType = tokenType;
+		this.Split = ChooseSplit(tokenType);
+	}
 
+	static Split<TSpan> ChooseSplit(TokenType tokenType)
+	{
+		// I will type inference would make this unnecessary, but couldn't find a way.
+		// Just encapsualting it to clean up the constructor.
 		Type type = typeof(TSpan);
 		if (type == typeof(byte))
 		{
-			this.Split = tokenType switch
+			return tokenType switch
 			{
 				TokenType.Words => Words.SplitUtf8Bytes as Split<TSpan>,
 				TokenType.Graphemes => Graphemes.SplitUtf8Bytes as Split<TSpan>,
@@ -91,7 +97,7 @@ public ref struct Tokenizer<TSpan> where TSpan : struct
 		}
 		else if (type == typeof(char))
 		{
-			this.Split = tokenType switch
+			return tokenType switch
 			{
 				TokenType.Words => Words.SplitChars as Split<TSpan>,
 				TokenType.Graphemes => Graphemes.SplitChars as Split<TSpan>,

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -1,14 +1,13 @@
 namespace uax29;
 
 using System.ComponentModel;
-using System.Globalization;
 
 public enum TokenType
 {
 	Words, Graphemes, Sentences
 }
 
-public delegate int Split<T>(ReadOnlySpan<T> input, bool atEOF = true);
+public delegate int Split<TSpan>(ReadOnlySpan<TSpan> input, bool atEOF = true);
 
 public static class Tokenizer
 {
@@ -18,8 +17,8 @@ public static class Tokenizer
 	/// <param name="input">The string to tokenize.</param>
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
 	/// <returns>
-	/// A tokenizer to iterate over, using <see cref="Tokenizer{T}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{T}.Current"/>.
-	/// <see cref="Tokenizer{T}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
+	/// A tokenizer to iterate over, using <see cref="Tokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="Tokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
 	/// </returns>
 	public static Tokenizer<char> Create(string input, TokenType tokenType = TokenType.Words)
 	{
@@ -32,8 +31,8 @@ public static class Tokenizer
 	/// <param name="input">The UTF-8 bytes to tokenize.</param>
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
 	/// <returns>
-	/// A tokenizer to iterate over, using <see cref="Tokenizer{T}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{T}.Current"/>.
-	/// <see cref="Tokenizer{T}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
+	/// A tokenizer to iterate over, using <see cref="Tokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="Tokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
 	/// </returns>
 	public static Tokenizer<byte> Create(ReadOnlySpan<byte> input, TokenType tokenType = TokenType.Words)
 	{
@@ -46,8 +45,8 @@ public static class Tokenizer
 	/// <param name="input">The string to tokenize.</param>
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
 	/// <returns>
-	/// A tokenizer to iterate over, using <see cref="Tokenizer{T}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{T}.Current"/>.
-	/// <see cref="Tokenizer{T}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
+	/// A tokenizer to iterate over, using <see cref="Tokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="Tokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
 	/// </returns>
 	public static Tokenizer<char> Create(ReadOnlySpan<char> input, TokenType tokenType = TokenType.Words)
 	{
@@ -57,12 +56,12 @@ public static class Tokenizer
 
 /// <summary>
 /// Tokenizer splits strings or UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
-/// Use <see cref="Tokenizer{T}.MoveNext"/> to iterate, and <see cref="Tokenizer{T}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
+/// Use <see cref="Tokenizer{TSpan}.MoveNext"/> to iterate, and <see cref="Tokenizer{TSpan}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
 /// </summary>
-public ref struct Tokenizer<T> where T : struct
+public ref struct Tokenizer<TSpan> where TSpan : struct
 {
-	readonly ReadOnlySpan<T> input;
-	readonly Split<T> Split;
+	readonly ReadOnlySpan<TSpan> input;
+	readonly Split<TSpan> Split;
 	public readonly TokenType TokenType;
 
 	int start = 0;
@@ -73,19 +72,19 @@ public ref struct Tokenizer<T> where T : struct
 	/// </summary>
 	/// <param name="input">A string, or UTF-8 byte array.</param>
 	/// <param name="tokenType">Choose to split words, graphemes or sentences. Default is words.</param>
-	internal Tokenizer(ReadOnlySpan<T> input, TokenType tokenType = TokenType.Words)
+	internal Tokenizer(ReadOnlySpan<TSpan> input, TokenType tokenType = TokenType.Words)
 	{
 		this.input = input;
 		this.TokenType = tokenType;
 
-		Type type = typeof(T);
+		Type type = typeof(TSpan);
 		if (type == typeof(byte))
 		{
 			this.Split = tokenType switch
 			{
-				TokenType.Words => Words.SplitUtf8Bytes as Split<T>,
-				TokenType.Graphemes => Graphemes.SplitUtf8Bytes as Split<T>,
-				TokenType.Sentences => Sentences.SplitUtf8Bytes as Split<T>,
+				TokenType.Words => Words.SplitUtf8Bytes as Split<TSpan>,
+				TokenType.Graphemes => Graphemes.SplitUtf8Bytes as Split<TSpan>,
+				TokenType.Sentences => Sentences.SplitUtf8Bytes as Split<TSpan>,
 				// I wish T were inferrable simply by choice of the above generic delegates!
 				_ => throw new InvalidEnumArgumentException(nameof(tokenType), (int)tokenType, typeof(TokenType))
 			} ?? throw new NotImplementedException();
@@ -94,9 +93,9 @@ public ref struct Tokenizer<T> where T : struct
 		{
 			this.Split = tokenType switch
 			{
-				TokenType.Words => Words.SplitChars as Split<T>,
-				TokenType.Graphemes => Graphemes.SplitChars as Split<T>,
-				TokenType.Sentences => Sentences.SplitChars as Split<T>,
+				TokenType.Words => Words.SplitChars as Split<TSpan>,
+				TokenType.Graphemes => Graphemes.SplitChars as Split<TSpan>,
+				TokenType.Sentences => Sentences.SplitChars as Split<TSpan>,
 				_ => throw new InvalidEnumArgumentException(nameof(tokenType), (int)tokenType, typeof(TokenType))
 			} ?? throw new NotImplementedException();
 		}
@@ -134,7 +133,7 @@ public ref struct Tokenizer<T> where T : struct
 	/// If the input was a string, <see cref="Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
 	/// If the input was UTF-8 bytes, <see cref="Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
 	/// </summary>
-	public readonly ReadOnlySpan<T> Current
+	public readonly ReadOnlySpan<TSpan> Current
 	{
 		get
 		{

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -87,7 +87,7 @@ internal static partial class Words
                 }
 
                 // https://unicode.org/reports/tr29/#WB3
-                if (current.Iss(LF) && last.Iss(CR))
+                if (current.Is(LF) && last.Is(CR))
                 {
                     pos += w;
                     continue;
@@ -95,27 +95,27 @@ internal static partial class Words
 
                 // https://unicode.org/reports/tr29/#WB3a
                 // https://unicode.org/reports/tr29/#WB3b
-                if ((last | current).Iss(Newline | CR | LF))
+                if ((last | current).Is(Newline | CR | LF))
                 {
                     break;
                 }
 
                 // https://unicode.org/reports/tr29/#WB3c
-                if (current.Iss(Extended_Pictographic) && last.Iss(ZWJ))
+                if (current.Is(Extended_Pictographic) && last.Is(ZWJ))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#WB3d
-                if ((current & last).Iss(WSegSpace))
+                if ((current & last).Is(WSegSpace))
                 {
                     pos += w;
                     continue;
                 }
 
                 // https://unicode.org/reports/tr29/#WB4
-                if (current.Iss(Extend | Format | ZWJ))
+                if (current.Is(Extend | Format | ZWJ))
                 {
                     pos += w;
                     continue;
@@ -126,10 +126,10 @@ internal static partial class Words
                 // The previous/subsequent methods are shorthand for "seek a property but skip over Extend|Format|ZWJ on the way"
 
                 // https://unicode.org/reports/tr29/#WB5
-                if (current.Iss(AHLetter) && last.Iss(AHLetter | Ignore))
+                if (current.Is(AHLetter) && last.Is(AHLetter | Ignore))
                 {
                     // Optimization: maybe a run without ignored characters
-                    if (last.Iss(AHLetter))
+                    if (last.Is(AHLetter))
                     {
                         pos += w;
                         while (pos < input.Length)
@@ -146,7 +146,7 @@ internal static partial class Words
                             }
 
                             var lookup = Dict.Lookup(rune2.Value);
-                            if (!lookup.Iss(AHLetter))
+                            if (!lookup.Is(AHLetter))
                             {
                                 break;
                             }
@@ -169,7 +169,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB6 can possibly apply
-                var maybeWB6 = current.Iss(MidLetter | MidNumLetQ) && last.Iss(AHLetter | Ignore);
+                var maybeWB6 = current.Is(MidLetter | MidNumLetQ) && last.Is(AHLetter | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB6
                 if (maybeWB6)
@@ -182,7 +182,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB7 can possibly apply
-                var maybeWB7 = current.Iss(AHLetter) && last.Iss(MidLetter | MidNumLetQ | Ignore);
+                var maybeWB7 = current.Is(AHLetter) && last.Is(MidLetter | MidNumLetQ | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB7
                 if (maybeWB7)
@@ -196,7 +196,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB7a can possibly apply
-                var maybeWB7a = current.Iss(Single_Quote) && last.Iss(Hebrew_Letter | Ignore);
+                var maybeWB7a = current.Is(Single_Quote) && last.Is(Hebrew_Letter | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB7a
                 if (maybeWB7a)
@@ -209,7 +209,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB7b can possibly apply
-                var maybeWB7b = current.Iss(Double_Quote) && last.Iss(Hebrew_Letter | Ignore);
+                var maybeWB7b = current.Is(Double_Quote) && last.Is(Hebrew_Letter | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB7b
                 if (maybeWB7b)
@@ -222,7 +222,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB7c can possibly apply
-                var maybeWB7c = current.Iss(Hebrew_Letter) && last.Iss(Double_Quote | Ignore);
+                var maybeWB7c = current.Is(Hebrew_Letter) && last.Is(Double_Quote | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB7c
                 if (maybeWB7c)
@@ -238,13 +238,13 @@ internal static partial class Words
                 // https://unicode.org/reports/tr29/#WB8
                 // https://unicode.org/reports/tr29/#WB9
                 // https://unicode.org/reports/tr29/#WB10
-                if (current.Iss(Numeric | AHLetter) && last.Iss(Numeric | AHLetter | Ignore))
+                if (current.Is(Numeric | AHLetter) && last.Is(Numeric | AHLetter | Ignore))
                 {
                     // Note: this logic de facto expresses WB5 as well, but harmless since WB5
                     // was already tested above
 
                     // Optimization: maybe a run without ignored characters
-                    if (last.Iss(Numeric | AHLetter))
+                    if (last.Is(Numeric | AHLetter))
                     {
                         pos += w;
                         while (pos < input.Length)
@@ -262,7 +262,7 @@ internal static partial class Words
 
                             var lookup = Dict.Lookup(rune2.Value);
 
-                            if (!lookup.Iss(Numeric | AHLetter))
+                            if (!lookup.Is(Numeric | AHLetter))
                             {
                                 break;
                             }
@@ -289,7 +289,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB11 can possibly apply
-                var maybeWB11 = current.Iss(Numeric) && last.Iss(MidNum | MidNumLetQ | Ignore);
+                var maybeWB11 = current.Is(Numeric) && last.Is(MidNum | MidNumLetQ | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB11
                 if (maybeWB11)
@@ -303,7 +303,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB12 can possibly apply
-                var maybeWB12 = current.Iss(MidNum | MidNumLetQ) && last.Iss(Numeric | Ignore);
+                var maybeWB12 = current.Is(MidNum | MidNumLetQ) && last.Is(Numeric | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB12
                 if (maybeWB12)
@@ -316,10 +316,10 @@ internal static partial class Words
                 }
 
                 // https://unicode.org/reports/tr29/#WB13
-                if (current.Iss(Katakana) && last.Iss(Katakana | Ignore))
+                if (current.Is(Katakana) && last.Is(Katakana | Ignore))
                 {
                     // Optimization: maybe a run without ignored characters
-                    if (last.Iss(Katakana))
+                    if (last.Is(Katakana))
                     {
                         pos += w;
                         while (pos < input.Length)
@@ -336,7 +336,7 @@ internal static partial class Words
                             }
 
                             var lookup = Dict.Lookup(rune2.Value);
-                            if (!lookup.Iss(Katakana))
+                            if (!lookup.Is(Katakana))
                             {
                                 break;
                             }
@@ -359,7 +359,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB13a can possibly apply
-                var maybeWB13a = current.Iss(ExtendNumLet) && last.Iss(AHLetter | Numeric | Katakana | ExtendNumLet | Ignore);
+                var maybeWB13a = current.Is(ExtendNumLet) && last.Is(AHLetter | Numeric | Katakana | ExtendNumLet | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB13a
                 if (maybeWB13a)
@@ -372,7 +372,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB13b can possibly apply
-                var maybeWB13b = current.Iss(AHLetter | Numeric | Katakana) && last.Iss(ExtendNumLet | Ignore);
+                var maybeWB13b = current.Is(AHLetter | Numeric | Katakana) && last.Is(ExtendNumLet | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB13b
                 if (maybeWB13b)
@@ -385,7 +385,7 @@ internal static partial class Words
                 }
 
                 // Optimization: determine if WB15 or WB16 can possibly apply
-                var maybeWB1516 = current.Iss(Regional_Indicator) && last.Iss(Regional_Indicator | Ignore);
+                var maybeWB1516 = current.Is(Regional_Indicator) && last.Is(Regional_Indicator | Ignore);
 
                 // https://unicode.org/reports/tr29/#WB15 and
                 // https://unicode.org/reports/tr29/#WB16
@@ -419,12 +419,12 @@ internal static partial class Words
                             break;
                         }
 
-                        if (lookup.Iss(Ignore))
+                        if (lookup.Is(Ignore))
                         {
                             continue;
                         }
 
-                        if (!lookup.Iss(Regional_Indicator))
+                        if (!lookup.Is(Regional_Indicator))
                         {
                             // It's WB16
                             break;

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -8,11 +8,11 @@ using Property = uint;
 
 internal static partial class Words
 {
-    internal static readonly Split Split = new Splitter(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split Split = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
 
-    internal class Splitter : SplitterBase
+    internal class Splitter<TSpan> : SplitterBase<TSpan>
     {
-        internal Splitter(Decoder decodeFirstRune, Decoder decodeLastRune) :
+        internal Splitter(Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune) :
             base(Words.Dict, Ignore, decodeFirstRune, decodeLastRune)
         { }
 
@@ -20,7 +20,7 @@ internal static partial class Words
         const Property MidNumLetQ = MidNumLet | Single_Quote;
         new const Property Ignore = Extend | Format | ZWJ;
 
-        public override int Split(ReadOnlySpan<byte> input, bool atEOF = true)
+        public override int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
         {
             if (input.Length == 0)
             {

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -8,7 +8,8 @@ using Property = uint;
 
 internal static partial class Words
 {
-    internal static readonly Split Split = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
+    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeFromUtf16).Split;
 
     internal class Splitter<TSpan> : SplitterBase<TSpan>
     {

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -9,7 +9,7 @@ using Property = uint;
 internal static partial class Words
 {
     internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
-    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeFromUtf16).Split;
+    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeLastFromUtf16).Split;
 
     internal class Splitter<TSpan> : SplitterBase<TSpan>
     {


### PR DESCRIPTION
A support for string (and `ReadOnlySpan<char>` by implication) in addition to UTF-8 bytes, via generic coolness.