### PR TITLE
Enumerator

### DIFF
--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -44,6 +44,17 @@ public class Benchmark
 		}
 	}
 
+
+	[Benchmark]
+	public void TokenizeStream()
+	{
+		var stream = new MemoryStream(sample);
+		var tokens = StreamTokenizer.Create(stream, tokenType);
+		while (tokens.MoveNext())
+		{
+		}
+	}
+
 	[Benchmark]
 	public void StringInfoGraphemes()
 	{

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -49,7 +49,7 @@ public class Benchmark
 	public void TokenizeStream()
 	{
 		var stream = new MemoryStream(sample);
-		var tokens = StreamTokenizer.Create(stream, tokenType);
+		var tokens = Tokenizer.Create(stream, tokenType);
 		while (tokens.MoveNext())
 		{
 		}

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -16,6 +16,7 @@ public class Benchmark
 {
 	static byte[] sample = [];
 	static string sampleStr = "";
+	Stream sampleStream = Stream.Null;
 
 	private static readonly TokenType tokenType = TokenType.Words;
 
@@ -24,6 +25,7 @@ public class Benchmark
 	{
 		sample = File.ReadAllBytes("/Users/msherman/Documents/code/src/github.com/clipperhouse/uax29.net/Benchmarks/sample.txt");
 		sampleStr = Encoding.UTF8.GetString(sample);
+		sampleStream = new MemoryStream(sample);
 	}
 
 	[Benchmark]
@@ -50,6 +52,16 @@ public class Benchmark
 	{
 		var stream = new MemoryStream(sample);
 		var tokens = Tokenizer.Create(stream, tokenType);
+		while (tokens.MoveNext())
+		{
+		}
+	}
+
+	[Benchmark]
+	public void TokenizeSetStream()
+	{
+		sampleStream.Seek(0, SeekOrigin.Begin);
+		var tokens = Tokenizer.Create(sampleStream, tokenType);
 		while (tokens.MoveNext())
 		{
 		}

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -60,10 +60,16 @@ public class Benchmark
 	[Benchmark]
 	public void TokenizeSetStream()
 	{
-		sampleStream.Seek(0, SeekOrigin.Begin);
 		var tokens = Tokenizer.Create(sampleStream, tokenType);
-		while (tokens.MoveNext())
+
+		var runs = 10;
+		for (var i = 0; i < runs; i++)
 		{
+			sampleStream.Seek(0, SeekOrigin.Begin);
+			tokens.SetStream(sampleStream);
+			while (tokens.MoveNext())
+			{
+			}
 		}
 	}
 

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -60,11 +60,16 @@ public class Benchmark
 	[Benchmark]
 	public void TokenizeSetStream()
 	{
+		// This is to test to observe allocations.
+
+		// The creation will allocate a buffer of 1024 bytes
 		var tokens = Tokenizer.Create(sampleStream, tokenType);
 
 		var runs = 10;
+		// keep in mind the 10 runs when interpreting the benchmark
 		for (var i = 0; i < runs; i++)
 		{
+			// subsequent runs should allocate less by using SetStream
 			sampleStream.Seek(0, SeekOrigin.Begin);
 			tokens.SetStream(sampleStream);
 			while (tokens.MoveNext())

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ text
 
 The constructor above has an optional second parameter to specify whether you wish to split words, graphemes, or sentences.
 
+You can also pass a `Stream` of UTF-8 bytes, or a `TextReader`/`StreamReader` of `char`.
+
 ### Conformance
 
 We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#Tests29). Status:
@@ -71,9 +73,11 @@ We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#
 
 ### Performance
 
-When tokenizing words, I get around 100MB/s on my Macbook M2. For typical text, that's around 25MM tokens/s, assuming tokens average 4 bytes. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
+When tokenizing words, I get around 100MB/s on my Macbook M2. For typical text, that's around 25MM tokens/s. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
 
-The tokenizer is implemented as a `ref struct`, so you should see zero allocations.
+The tokenizer is implemented as a `ref struct`, so you should see zero allocations for static text such as `byte[]` or `string`/`char`.
+
+For `Stream` or `TextReader`/`StreamReader`, a default `byte[1024]` buffer needs to be allocated behind the scenes. You can specify the size when calling `Create`. You can re-use the buffer by calling `SetStream` on an existing tokenizer, which will avoid re-allocation.   
 
 ### Invalid inputs
 
@@ -83,7 +87,7 @@ The tokenizer expects valid (decodable) UTF-8 bytes or UTF-16 chars as input. We
 
 [clipperhouse/uax29](https://github.com/clipperhouse/uax29)
 
-I previously implemented this for Go. This .Net version is something of a port of that.
+I previously implemented this for Go.
 
 [StringInfo.GetTextElementEnumerator](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.stringinfo.gettextelementenumerator?view=net-8.0)
 

--- a/Tests/TokenizerTests.cs
+++ b/Tests/TokenizerTests.cs
@@ -165,9 +165,9 @@ public class TestTokenizer
 		tokens.SetStream(stream2);
 
 		var second = new List<string>();
-		while (tokens.MoveNext())
+		foreach (var token in tokens)
 		{
-			var s = Encoding.UTF8.GetString(tokens.Current);
+			var s = Encoding.UTF8.GetString(token);
 			second.Add(s);
 		}
 
@@ -199,12 +199,69 @@ public class TestTokenizer
 		tokens.SetStream(reader2);
 
 		var second = new List<string>();
-		while (tokens.MoveNext())
+		foreach (var token in tokens)
 		{
-			var s = tokens.Current.ToString();
+			var s = token.ToString();
 			second.Add(s);
 		}
 
+		Assert.That(first.SequenceEqual(second));
+	}
+
+	[Test]
+	public void EnumeratorTest()
+	{
+		var input = "Hello, how are you?";
+
+		var tokens = Tokenizer.Create(input);
+
+		var first = new List<string>();
+		while (tokens.MoveNext())
+		{
+			var s = tokens.Current.ToString();
+			first.Add(s);
+		}
+
+		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
+
+		var tokens2 = Tokenizer.Create(input);
+
+		var second = new List<string>();
+		foreach (var token in tokens2)
+		{
+			var s = token.ToString();
+			second.Add(s);
+		}
+		Assert.That(first.SequenceEqual(second));
+	}
+
+	[Test]
+	public void EnumeratorStreamTest()
+	{
+		var input = "Hello, how are you?";
+		var bytes = Encoding.UTF8.GetBytes(input);
+		using var stream = new MemoryStream(bytes);
+
+		var tokens = Tokenizer.Create(stream);
+
+		var first = new List<string>();
+		while (tokens.MoveNext())
+		{
+			var s = tokens.Current.ToString();
+			first.Add(s);
+		}
+
+		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
+
+		using var stream2 = new MemoryStream(bytes);
+		var tokens2 = Tokenizer.Create(stream2);
+
+		var second = new List<string>();
+		foreach (var token in tokens2)
+		{
+			var s = token.ToString();
+			second.Add(s);
+		}
 		Assert.That(first.SequenceEqual(second));
 	}
 }

--- a/Tests/TokenizerTests.cs
+++ b/Tests/TokenizerTests.cs
@@ -174,7 +174,6 @@ public class TestTokenizer
 		Assert.That(first.SequenceEqual(second));
 	}
 
-
 	[Test]
 	public void SetStreamReader()
 	{

--- a/Tests/TokenizerTests.cs
+++ b/Tests/TokenizerTests.cs
@@ -88,7 +88,7 @@ public class TestTokenizer
 			var staticTokens = Tokenizer.Create(bytes);
 
 			using var stream = new MemoryStream(bytes);
-			var streamedTokens = Tokenizer.Create(stream);
+			var streamedTokens = StreamTokenizer.Create(stream);
 
 			while (streamedTokens.MoveNext())
 			{
@@ -112,7 +112,7 @@ public class TestTokenizer
 		var bytes = Encoding.UTF8.GetBytes(input);
 		using var stream = new MemoryStream(bytes);
 
-		var tokens = Tokenizer.Create(stream);
+		var tokens = StreamTokenizer.Create(stream);
 
 		var first = new List<string>();
 		while (tokens.MoveNext())

--- a/Tests/TokenizerTests.cs
+++ b/Tests/TokenizerTests.cs
@@ -4,70 +4,137 @@ using uax29;
 using NUnit.Framework.Internal;
 using System.Linq;
 using System.Text;
+using Microsoft.VisualBasic;
 
 [TestFixture]
 public class TestTokenizer
 {
-    [SetUp]
-    public void Setup()
-    {
-    }
+	[SetUp]
+	public void Setup()
+	{
+	}
 
-    [Test]
-    public void Reset()
-    {
-        var example = "Hello, how are you?";
-        var bytes = Encoding.UTF8.GetBytes(example);
+	[Test]
+	public void Reset()
+	{
+		var example = "Hello, how are you?";
+		var bytes = Encoding.UTF8.GetBytes(example);
 
-        var tokens = Tokenizer.Create(example);
+		var tokens = Tokenizer.Create(example);
 
-        var first = new List<string>();
-        while (tokens.MoveNext())
-        {
-            // do something with tokens.Current
-            first.Add(tokens.Current.ToString());
-        }
+		var first = new List<string>();
+		while (tokens.MoveNext())
+		{
+			// do something with tokens.Current
+			first.Add(tokens.Current.ToString());
+		}
 
-        Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
+		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
 
-        tokens.Reset();
+		tokens.Reset();
 
-        var second = new List<string>();
-        while (tokens.MoveNext())
-        {
-            // do something with tokens.Current
-            second.Add(tokens.Current.ToString());
-        }
+		var second = new List<string>();
+		while (tokens.MoveNext())
+		{
+			// do something with tokens.Current
+			second.Add(tokens.Current.ToString());
+		}
 
-        Assert.That(first.SequenceEqual(second));
-    }
+		Assert.That(first.SequenceEqual(second));
+	}
 
-    [Test]
-    public void SetText()
-    {
-        var example = "Hello, how are you?";
+	[Test]
+	public void SetText()
+	{
+		var example = "Hello, how are you?";
 
-        var tokens = Tokenizer.Create(example);
+		var tokens = Tokenizer.Create(example);
 
-        var first = new List<string>();
-        while (tokens.MoveNext())
-        {
-            // do something with tokens.Current
-            first.Add(tokens.Current.ToString());
-        }
+		var first = new List<string>();
+		while (tokens.MoveNext())
+		{
+			first.Add(tokens.Current.ToString());
+		}
 
-        Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
+		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
 
-        tokens.SetText(example);
+		tokens.SetText(example);
 
-        var second = new List<string>();
-        while (tokens.MoveNext())
-        {
-            // do something with tokens.Current
-            second.Add(tokens.Current.ToString());
-        }
+		var second = new List<string>();
+		while (tokens.MoveNext())
+		{
+			second.Add(tokens.Current.ToString());
+		}
 
-        Assert.That(first.SequenceEqual(second));
-    }
+		Assert.That(first.SequenceEqual(second));
+	}
+
+	/// <summary>
+	/// Ensure that streamed text and static text return identical results.
+	/// </summary>
+	[Test]
+	public void StreamTest()
+	{
+		var example = "abcdefghijk lmnopq r stu vwxyz; ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";
+		var examples = new List<string>()
+		{
+			example,											// smaller than the buffer
+			string.Concat(Enumerable.Repeat(example, 999))		// larger than the buffer
+		};
+
+		foreach (var input in examples)
+		{
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var staticTokens = Tokenizer.Create(bytes);
+
+			using var stream = new MemoryStream(bytes);
+			var streamedTokens = Tokenizer.Create(stream);
+
+			while (streamedTokens.MoveNext())
+			{
+				staticTokens.MoveNext();
+
+				var staticCurrent = Encoding.UTF8.GetString(staticTokens.Current);
+				var streamingCurrent = Encoding.UTF8.GetString(streamedTokens.Current);
+
+				Assert.That(staticCurrent, Is.EqualTo(streamingCurrent));
+			}
+
+			Assert.That(staticTokens.MoveNext(), Is.False, "Static tokens should have been consumed");
+			Assert.That(streamedTokens.MoveNext(), Is.False, "Streamed tokens should have been consumed");
+		}
+	}
+
+	[Test]
+	public void SetStream()
+	{
+		var input = "Hello, how are you?";
+		var bytes = Encoding.UTF8.GetBytes(input);
+		using var stream = new MemoryStream(bytes);
+
+		var tokens = Tokenizer.Create(stream);
+
+		var first = new List<string>();
+		while (tokens.MoveNext())
+		{
+			var s = Encoding.UTF8.GetString(tokens.Current);
+			first.Add(s);
+		}
+
+		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
+
+		using var stream2 = new MemoryStream(bytes);
+
+		tokens.SetStream(stream2);
+
+		var second = new List<string>();
+		while (tokens.MoveNext())
+		{
+			var s = Encoding.UTF8.GetString(tokens.Current);
+			second.Add(s);
+		}
+
+		Assert.That(first.SequenceEqual(second));
+	}
 }
 

--- a/uax29/README.md
+++ b/uax29/README.md
@@ -63,6 +63,8 @@ text
 
 The constructor above has an optional second parameter to specify whether you wish to split words, graphemes, or sentences.
 
+You can also pass a `Stream` of UTF-8 bytes, or a `TextReader`/`StreamReader` of `char`.
+
 ### Conformance
 
 We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#Tests29). Status:
@@ -71,9 +73,11 @@ We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#
 
 ### Performance
 
-When tokenizing words, I get around 100MB/s on my Macbook M2. For typical text, that's around 25MM tokens/s, assuming tokens average 4 bytes. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
+When tokenizing words, I get around 100MB/s on my Macbook M2. For typical text, that's around 25MM tokens/s. [Benchmarks](https://github.com/clipperhouse/uax29.net/tree/main/Benchmarks)
 
-The tokenizer is implemented as a `ref struct`, so you should see zero allocations.
+The tokenizer is implemented as a `ref struct`, so you should see zero allocations for static text such as `byte[]` or `string`/`char`.
+
+For `Stream` or `TextReader`/`StreamReader`, a default `byte[1024]` buffer needs to be allocated behind the scenes. You can specify the size when calling `Create`. You can re-use the buffer by calling `SetStream` on an existing tokenizer, which will avoid re-allocation.   
 
 ### Invalid inputs
 
@@ -83,7 +87,7 @@ The tokenizer expects valid (decodable) UTF-8 bytes or UTF-16 chars as input. We
 
 [clipperhouse/uax29](https://github.com/clipperhouse/uax29)
 
-I previously implemented this for Go. This .Net version is something of a port of that.
+I previously implemented this for Go.
 
 [StringInfo.GetTextElementEnumerator](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.stringinfo.gettextelementenumerator?view=net-8.0)
 

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -1,29 +1,5 @@
 ﻿namespace uax29;
 
-public static class StreamTokenizer
-{
-
-	/// <summary>
-	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
-	/// </summary>
-	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
-	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
-	/// <param name="maxTokenBytes">
-	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
-	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
-	/// </param>
-	/// <returns>
-	/// A tokenizer to iterate over, using <see cref="StreamTokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
-	/// <see cref="StreamTokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
-	/// </returns>
-	public static StreamTokenizer<byte> Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
-	{
-		var tok = Tokenizer.Create(ReadOnlySpan<byte>.Empty, tokenType);
-		return new StreamTokenizer<byte>(stream, tok, maxTokenBytes);
-	}
-}
-
 /// <summary>
 /// Tokenizer splits a stream of UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
 /// Use <see cref="StreamTokenizer{TSpan}.MoveNext"/> to iterate, and <see cref="StreamTokenizer{TSpan}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
@@ -50,6 +26,12 @@ public ref struct StreamTokenizer<T> where T : struct
 		buffer = new Buffer<byte>(stream.Read, maxTokenBytes) as Buffer<T> ?? throw new NotImplementedException();
 	}
 
+	internal StreamTokenizer(StreamReader stream, Tokenizer<T> tok, int maxTokenBytes = 1024)
+	{
+		this.tok = tok;
+		buffer = new Buffer<char>(stream.Read, maxTokenBytes) as Buffer<T> ?? throw new NotImplementedException();
+	}
+
 	readonly ReadOnlySpan<T> empty = [];
 
 	public bool MoveNext()
@@ -66,6 +48,12 @@ public ref struct StreamTokenizer<T> where T : struct
 	{
 		this.tok.SetText(empty);
 		buffer = new Buffer<byte>(stream.Read, buffer.storage.Length) as Buffer<T> ?? throw new NotImplementedException();
+	}
+
+	public void SetStream(StreamReader stream)
+	{
+		this.tok.SetText(empty);
+		buffer = new Buffer<char>(stream.Read, buffer.storage.Length) as Buffer<T> ?? throw new NotImplementedException();
 	}
 }
 

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -39,13 +39,13 @@ public ref struct StreamTokenizer<T> where T : struct
 
 public static class StreamExtensions
 {
-	public static void SetStream(this StreamTokenizer<byte> stok, Stream stream)
+	public static void SetStream(ref this StreamTokenizer<byte> stok, Stream stream)
 	{
 		stok.tok.SetText([]);
 		stok.buffer.SetRead(stream.Read);
 	}
 
-	public static void SetStream(this StreamTokenizer<char> stok, TextReader stream)
+	public static void SetStream(ref this StreamTokenizer<char> stok, TextReader stream)
 	{
 		stok.tok.SetText([]);
 		stok.buffer.SetRead(stream.Read);
@@ -54,7 +54,7 @@ public static class StreamExtensions
 
 internal delegate int Read<T>(T[] buffer, int offset, int count) where T : struct;
 
-internal class Buffer<T> where T : struct
+internal ref struct Buffer<T> where T : struct
 {
 	readonly T[] storage;
 	Read<T> Read;

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -35,6 +35,11 @@ public ref struct StreamTokenizer<T> where T : struct
 	}
 
 	public readonly ReadOnlySpan<T> Current => tok.Current;
+
+	public readonly StreamTokenizer<T> GetEnumerator()
+	{
+		return this;
+	}
 }
 
 public static class StreamExtensions

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -17,7 +17,7 @@ public ref struct StreamTokenizer<T> where T : struct
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
 	/// <param name="maxTokenBytes">
 	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Defaults is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
 	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
 	/// </param>
 	internal StreamTokenizer(Buffer<T> buffer, Tokenizer<T> tok, int maxTokenBytes = 1024)

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -26,8 +26,6 @@ public ref struct StreamTokenizer<T> where T : struct
 		this.buffer = buffer;
 	}
 
-	readonly ReadOnlySpan<T> empty = [];
-
 	public bool MoveNext()
 	{
 		buffer.Consume(tok.Current.Length); // the previous token
@@ -47,7 +45,7 @@ public static class StreamExtensions
 		stok.buffer.SetRead(stream.Read);
 	}
 
-	public static void SetStream(this StreamTokenizer<char> stok, StreamReader stream)
+	public static void SetStream(this StreamTokenizer<char> stok, TextReader stream)
 	{
 		stok.tok.SetText([]);
 		stok.buffer.SetRead(stream.Read);

--- a/uax29/StreamingTokenizer.cs
+++ b/uax29/StreamingTokenizer.cs
@@ -1,0 +1,83 @@
+﻿using System.Text;
+
+namespace uax29;
+
+/// <summary>
+/// Tokenizer splits a stream of UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
+/// Use <see cref="StreamingTokenizer{TSpan}.MoveNext"/> to iterate, and <see cref="StreamingTokenizer{TSpan}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
+/// </summary>
+public ref struct StreamingTokenizer
+{
+	Tokenizer<byte> tok;
+
+	Buffer buffer;
+
+	/// <summary>
+	/// Tokenizer splits strings (or UTF-8 bytes) as words, sentences or graphemes, per the Unicode UAX #29 spec.
+	/// </summary>
+	/// <param name="stream">A stream of UTF-8 encoded bytes.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Defaults is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	internal StreamingTokenizer(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		tok = new Tokenizer<byte>(null, tokenType);
+		buffer = new Buffer(stream, maxTokenBytes);
+	}
+
+	public bool MoveNext()
+	{
+		buffer.Consume(tok.Current.Length); // the previous token
+		var input = buffer.Contents;
+		tok.SetText(input);
+		return tok.MoveNext();
+	}
+
+	public readonly ReadOnlySpan<byte> Current => tok.Current;
+
+	public void SetStream(Stream stream)
+	{
+		this.tok.SetText(null);
+		this.buffer.SetStream(stream);
+	}
+}
+
+internal ref struct Buffer
+{
+	readonly byte[] storage;
+	int end = 0;
+	Stream stream;
+
+	internal Buffer(Stream stream, int size)
+	{
+		this.stream = stream;
+		storage = new byte[size];
+	}
+
+	internal ReadOnlySpan<byte> Contents
+	{
+		get
+		{
+			var read = stream.Read(storage, end, storage.Length - end);
+			end += read;
+
+			return storage.AsSpan(0, end);
+		}
+	}
+
+	internal void Consume(int consumed)
+	{
+		// Move the remaining unconsumed data to the start of the buffer
+		end -= consumed;
+		Array.Copy(storage, consumed, storage, 0, end);
+	}
+
+	internal void SetStream(Stream stream)
+	{
+		this.stream = stream;
+		end = 0;
+	}
+}

--- a/uax29/StreamingTokenizer.cs
+++ b/uax29/StreamingTokenizer.cs
@@ -1,12 +1,35 @@
-﻿using System.Text;
+﻿namespace uax29;
 
-namespace uax29;
+internal delegate int Read(byte[] buffer, int offset, int count);
+
+public static class StreamTokenizer
+{
+
+	/// <summary>
+	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="StreamTokenizerImpl{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="StreamTokenizerImpl{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
+	/// </returns>
+	public static StreamTokenizerImpl Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		return new StreamTokenizerImpl(stream, tokenType, maxTokenBytes);
+	}
+}
 
 /// <summary>
 /// Tokenizer splits a stream of UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
-/// Use <see cref="StreamingTokenizer{TSpan}.MoveNext"/> to iterate, and <see cref="StreamingTokenizer{TSpan}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
+/// Use <see cref="StreamTokenizerImpl{TSpan}.MoveNext"/> to iterate, and <see cref="StreamTokenizerImpl{TSpan}.Current"/> to retrive the current token (i.e. the word, grapheme or sentence).
 /// </summary>
-public ref struct StreamingTokenizer
+public ref struct StreamTokenizerImpl
 {
 	Tokenizer<byte> tok;
 
@@ -22,10 +45,10 @@ public ref struct StreamingTokenizer
 	/// Defaults is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
 	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
 	/// </param>
-	internal StreamingTokenizer(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	internal StreamTokenizerImpl(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
 	{
 		tok = new Tokenizer<byte>(null, tokenType);
-		buffer = new Buffer(stream, maxTokenBytes);
+		buffer = new Buffer(stream.Read, maxTokenBytes);
 	}
 
 	public bool MoveNext()
@@ -41,7 +64,7 @@ public ref struct StreamingTokenizer
 	public void SetStream(Stream stream)
 	{
 		this.tok.SetText(null);
-		this.buffer.SetStream(stream);
+		this.buffer.SetRead(stream.Read);
 	}
 }
 
@@ -49,11 +72,11 @@ internal ref struct Buffer
 {
 	readonly byte[] storage;
 	int end = 0;
-	Stream stream;
+	Read Read;
 
-	internal Buffer(Stream stream, int size)
+	internal Buffer(Read read, int size)
 	{
-		this.stream = stream;
+		this.Read = read;
 		storage = new byte[size];
 	}
 
@@ -61,7 +84,7 @@ internal ref struct Buffer
 	{
 		get
 		{
-			var read = stream.Read(storage, end, storage.Length - end);
+			var read = Read(storage, end, storage.Length - end);
 			end += read;
 
 			return storage.AsSpan(0, end);
@@ -75,9 +98,9 @@ internal ref struct Buffer
 		Array.Copy(storage, consumed, storage, 0, end);
 	}
 
-	internal void SetStream(Stream stream)
+	internal void SetRead(Read read)
 	{
-		this.stream = stream;
+		this.Read = read;
 		end = 0;
 	}
 }

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -52,6 +52,47 @@ public static class Tokenizer
 	{
 		return new Tokenizer<char>(input, tokenType);
 	}
+
+	/// <summary>
+	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="StreamTokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="StreamTokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
+	/// </returns>
+	/// 
+	public static StreamTokenizer<byte> Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		var tok = Create(ReadOnlySpan<byte>.Empty, tokenType);
+		return new StreamTokenizer<byte>(stream, tok, maxTokenBytes);
+	}
+
+	/// <summary>
+	/// Create a tokenizer for a stream reader of char, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="stream">The stream reader of char to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="StreamTokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="StreamTokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
+	/// </returns>
+	public static StreamTokenizer<char> Create(StreamReader stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		var tok = Create(ReadOnlySpan<char>.Empty, tokenType);
+		return new StreamTokenizer<char>(stream, tok, maxTokenBytes);
+	}
 }
 
 /// <summary>

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -40,25 +40,6 @@ public static class Tokenizer
 	}
 
 	/// <summary>
-	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
-	/// </summary>
-	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
-	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
-	/// <param name="maxTokenBytes">
-	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
-	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
-	/// </param>
-	/// <returns>
-	/// A tokenizer to iterate over, using <see cref="StreamingTokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
-	/// <see cref="StreamingTokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
-	/// </returns>
-	public static StreamingTokenizer Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
-	{
-		return new StreamingTokenizer(stream, tokenType, maxTokenBytes);
-	}
-
-	/// <summary>
 	/// Create a tokenizer for a <see cref="ReadOnlySpan"/> of <see cref="char"/>, to split words, graphemes or sentences.
 	/// </summary>
 	/// <param name="input">The string to tokenize.</param>

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -40,6 +40,25 @@ public static class Tokenizer
 	}
 
 	/// <summary>
+	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	/// <returns>
+	/// A tokenizer to iterate over, using <see cref="StreamingTokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
+	/// <see cref="StreamingTokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="byte"/>.
+	/// </returns>
+	public static StreamingTokenizer Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		return new StreamingTokenizer(stream, tokenType, maxTokenBytes);
+	}
+
+	/// <summary>
 	/// Create a tokenizer for a <see cref="ReadOnlySpan"/> of <see cref="char"/>, to split words, graphemes or sentences.
 	/// </summary>
 	/// <param name="input">The string to tokenize.</param>
@@ -61,6 +80,7 @@ public static class Tokenizer
 public ref struct Tokenizer<TSpan> where TSpan : struct
 {
 	ReadOnlySpan<TSpan> input;
+
 	readonly Split<TSpan> Split;
 	public readonly TokenType TokenType;
 

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -89,7 +89,7 @@ public static class Tokenizer
 	/// A tokenizer to iterate over, using <see cref="StreamTokenizer{TSpan}.MoveNext"/>, and retrieving each individual token with <see cref="Tokenizer{TSpan}.Current"/>.
 	/// <see cref="StreamTokenizer{TSpan}.Current"/> will be <see cref="ReadOnlySpan"/> of <see cref="char"/>.
 	/// </returns>
-	public static StreamTokenizer<char> Create(StreamReader stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	public static StreamTokenizer<char> Create(TextReader stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
 	{
 		var tok = Create(ReadOnlySpan<char>.Empty, tokenType);
 		var buffer = new Buffer<char>(stream.Read, maxTokenBytes);

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -191,6 +191,11 @@ public ref struct Tokenizer<TSpan> where TSpan : struct
 		}
 	}
 
+	public readonly Tokenizer<TSpan> GetEnumerator()
+	{
+		return this;
+	}
+
 	/// <summary>
 	/// Resets the tokenizer back to the first token.
 	/// </summary>

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -60,7 +60,7 @@ public static class Tokenizer
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
 	/// <param name="maxTokenBytes">
 	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
 	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
 	/// </param>
 	/// <returns>
@@ -82,7 +82,7 @@ public static class Tokenizer
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
 	/// <param name="maxTokenBytes">
 	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Defaults to 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
 	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
 	/// </param>
 	/// <returns>

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -71,7 +71,8 @@ public static class Tokenizer
 	public static StreamTokenizer<byte> Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
 	{
 		var tok = Create(ReadOnlySpan<byte>.Empty, tokenType);
-		return new StreamTokenizer<byte>(stream, tok, maxTokenBytes);
+		var buffer = new Buffer<byte>(stream.Read, maxTokenBytes);
+		return new StreamTokenizer<byte>(buffer, tok, maxTokenBytes);
 	}
 
 	/// <summary>
@@ -91,7 +92,8 @@ public static class Tokenizer
 	public static StreamTokenizer<char> Create(StreamReader stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
 	{
 		var tok = Create(ReadOnlySpan<char>.Empty, tokenType);
-		return new StreamTokenizer<char>(stream, tok, maxTokenBytes);
+		var buffer = new Buffer<char>(stream.Read, maxTokenBytes);
+		return new StreamTokenizer<char>(buffer, tok, maxTokenBytes);
 	}
 }
 


### PR DESCRIPTION
Add `GetEnumerator()` to `Tokenizer` and `StreamTokenizer`, allowing use of `foreach` instead of `MoveNext()`.