### PR TITLE
Moving buffer

### DIFF
--- a/uax29/Buffer.Test.cs
+++ b/uax29/Buffer.Test.cs
@@ -12,18 +12,24 @@ public class TestBuffer
         var input = "abcd efg hijkl mnopqr stu v wxyz";
         var bytes = Encoding.UTF8.GetBytes(input);
         using var stream = new MemoryStream(bytes);
+
         Read<byte> read = stream.Read;
         var buffer = new Buffer<byte>(read, 16);
 
         const int consume = 5;
+        int consumed = 0;
         string result = "";
 
         while (buffer.Contents.Length > 0)
         {
+            var contents = Encoding.UTF8.GetString(buffer.Contents);
+            Assert.That(input[consumed..], Does.StartWith(contents));
+
             var remaining = buffer.Contents.Length;
             var toConsume = remaining > consume ? remaining : consume;
             result += Encoding.UTF8.GetString(buffer.Contents[0..toConsume]);
             buffer.Consume(toConsume);
+            consumed += toConsume;
         }
 
         Assert.That(result, Is.EqualTo(input));

--- a/uax29/Buffer.Test.cs
+++ b/uax29/Buffer.Test.cs
@@ -6,34 +6,85 @@ using System.Text;
 [TestFixture]
 public class TestBuffer
 {
-    [Test]
-    public void Consume()
-    {
-        var input = "abcd efg hijkl mnopqr stu v wxyz";
-        var bytes = Encoding.UTF8.GetBytes(input);
-        using var stream = new MemoryStream(bytes);
+	[Test]
+	public void Consume()
+	{
+		var input = "abcd efg hijkl mnopqr stu v wxyz";
+		var bytes = Encoding.UTF8.GetBytes(input);
+		using var stream = new MemoryStream(bytes);
 
-        Read<byte> read = stream.Read;
-        var buffer = new Buffer<byte>(read, 16);
+		Read<byte> read = stream.Read;
+		var buffer = new Buffer<byte>(read, 16);
 
-        const int consume = 5;
-        int consumed = 0;
-        string result = "";
+		const int consume = 5;
+		int consumed = 0;
+		string result = "";
 
-        while (buffer.Contents.Length > 0)
-        {
-            var contents = Encoding.UTF8.GetString(buffer.Contents);
-            Assert.That(input[consumed..], Does.StartWith(contents));
+		while (buffer.Contents.Length > 0)
+		{
+			var contents = Encoding.UTF8.GetString(buffer.Contents);
+			Assert.That(input[consumed..], Does.StartWith(contents));
 
-            var remaining = buffer.Contents.Length;
-            var toConsume = remaining > consume ? remaining : consume;
-            result += Encoding.UTF8.GetString(buffer.Contents[0..toConsume]);
-            buffer.Consume(toConsume);
-            consumed += toConsume;
-        }
+			var remaining = buffer.Contents.Length;
+			var toConsume = remaining > consume ? remaining : consume;
+			result += Encoding.UTF8.GetString(buffer.Contents[0..toConsume]);
+			buffer.Consume(toConsume);
+			consumed += toConsume;
+		}
 
-        Assert.That(result, Is.EqualTo(input));
-    }
+		Assert.That(result, Is.EqualTo(input));
+	}
+
+	[Test]
+	public void Moving()
+	{
+		var input = "abcd efg hijkl mnopqr stu v wxyz; AB CDEF GH I JKLMN OPQ RST UVWXYZ";
+		var bytes = Encoding.UTF8.GetBytes(input);
+		using var stream = new MemoryStream(bytes);
+
+		const int maxTokenLength = 16;
+		const int factor = Buffer<byte>.factor;
+		const int storageSize = factor * maxTokenLength;
+
+		Read<byte> read = stream.Read;
+		var buffer = new Buffer<byte>(read, maxTokenLength);
+
+		var consumed = 0;
+
+		// Trigger a read by calling Contents, should be full
+		Assert.That(buffer.Contents.Length, Is.EqualTo(storageSize));
+		Assert.That(buffer.start, Is.EqualTo(0));
+		Assert.That(buffer.end, Is.EqualTo(storageSize));
+
+		{
+			// start should move, since we haven't consumed half yet
+			var consume = 4;
+			buffer.Consume(consume);
+			consumed += consume;
+
+			Assert.That(buffer.start, Is.EqualTo(consume));
+			Assert.That(buffer.end, Is.EqualTo(storageSize));
+
+			// trigger a read
+			Assert.That(buffer.Contents.Length, Is.EqualTo(storageSize - consumed));
+		}
+
+		{
+			// now exceed half of storage size
+			var consume = 15;
+			buffer.Consume(consume);
+			consumed += consume;   // gets us to 19 = 15 + 4
+
+			// should have moved the array contents to the front
+			Assert.That(buffer.start, Is.EqualTo(0));
+			Assert.That(buffer.end, Is.EqualTo(storageSize - consumed));
+
+			// trigger a read, should be full
+			Assert.That(buffer.Contents.Length, Is.EqualTo(storageSize));
+			Assert.That(buffer.start, Is.EqualTo(0));
+			Assert.That(buffer.end, Is.EqualTo(storageSize));
+		}
+	}
 }
 
 

--- a/uax29/Buffer.cs
+++ b/uax29/Buffer.cs
@@ -43,7 +43,7 @@ internal ref struct Buffer<T> where T : struct
         start += consumed;
 
         // Optimization: move the array less often
-        if (start > storage.Length / factor)
+        if (start >= storage.Length / factor)
         {
             // Move the remaining unconsumed data to the start of the buffer
             Array.Copy(storage, start, storage, 0, end - start);

--- a/uax29/Buffer.cs
+++ b/uax29/Buffer.cs
@@ -7,11 +7,12 @@ internal ref struct Buffer<T> where T : struct
     /// <summary>
     /// Allows the active span of the array to move with reduced copying.
     /// </summary>
-    const int factor = 2;
-    readonly T[] storage;
     Read<T> Read;
-    int start = 0;
-    int end = 0;
+
+    internal const int factor = 2;
+    internal readonly T[] storage;
+    internal int start = 0;
+    internal int end = 0;
 
     internal Buffer(Read<T> read, int maxTokenSize)
     {

--- a/uax29/Buffer.cs
+++ b/uax29/Buffer.cs
@@ -4,43 +4,58 @@ internal delegate int Read<T>(T[] buffer, int offset, int count) where T : struc
 
 internal ref struct Buffer<T> where T : struct
 {
+    /// <summary>
+    /// Allows the active span of the array to move with reduced copying.
+    /// </summary>
+    const int factor = 2;
     readonly T[] storage;
     Read<T> Read;
+    int start = 0;
     int end = 0;
 
-    internal Buffer(Read<T> read, int size)
+    internal Buffer(Read<T> read, int maxTokenSize)
     {
         this.Read = read;
-        storage = new T[size];
-    }
-
-    internal Buffer(Read<T> read, T[] storage)
-    {
-        this.Read = read;
-        this.storage = storage;
+        storage = new T[maxTokenSize * factor];
     }
 
     internal ReadOnlySpan<T> Contents
     {
         get
         {
-            var read = Read(storage, end, storage.Length - end);
-            end += read;
-
-            return storage.AsSpan(0, end);
+            if (end < storage.Length)
+            {
+                var read = Read(storage, end, storage.Length - end);
+                end += read;
+            }
+            return storage.AsSpan(start, end - start);
         }
     }
 
     internal void Consume(int consumed)
     {
-        // Move the remaining unconsumed data to the start of the buffer
-        end -= consumed;
-        Array.Copy(storage, consumed, storage, 0, end);
+        var remaining = end - start;
+        if (consumed > remaining)
+        {
+            consumed = remaining;
+        }
+
+        start += consumed;
+
+        // Optimization: move the array less often
+        if (start > storage.Length / factor)
+        {
+            // Move the remaining unconsumed data to the start of the buffer
+            Array.Copy(storage, start, storage, 0, end - start);
+            end -= start;
+            start = 0;
+        }
     }
 
     internal void SetRead(Read<T> read)
     {
         this.Read = read;
+        start = 0;
         end = 0;
     }
 }

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -1,5 +1,48 @@
 ﻿namespace uax29;
 
+public static partial class Tokenizer
+{
+	/// <summary>
+	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// Behind the scenes, a buffer of 2 * maxTokenSize will be created. If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	/// <returns>
+	/// An enumerator of tokens. Use foreach (var token in tokens).
+	/// </returns>
+	public static StreamTokenizer<byte> Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		var tok = Create(ReadOnlySpan<byte>.Empty, tokenType);
+		var buffer = new Buffer<byte>(stream.Read, maxTokenBytes);
+		return new StreamTokenizer<byte>(buffer, tok);
+	}
+
+	/// <summary>
+	/// Create a tokenizer for a stream reader of char, to split words, graphemes or sentences.
+	/// </summary>
+	/// <param name="stream">The stream/text reader of char to tokenize.</param>
+	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
+	/// <param name="maxTokenBytes">
+	/// Optional, the maximum token size in chars. Tokens that exceed this size will simply be cut off at this length, no error will occur.
+	/// Default is 1024 chars. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
+	/// Behind the scenes, a buffer of 2 * maxTokenSize will be created. If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
+	/// </param>
+	/// <returns>
+	/// An enumerator of tokens. Use foreach (var token in tokens).
+	/// </returns>
+	public static StreamTokenizer<char> Create(TextReader stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
+	{
+		var tok = Create(ReadOnlySpan<char>.Empty, tokenType);
+		var buffer = new Buffer<char>(stream.Read, maxTokenBytes);
+		return new StreamTokenizer<char>(buffer, tok);
+	}
+}
+
 /// <summary>
 /// Tokenizer splits a stream of UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
 /// </summary>
@@ -14,11 +57,6 @@ public ref struct StreamTokenizer<T> where T : struct
 	/// </summary>
 	/// <param name="stream">A stream of UTF-8 encoded bytes.</param>
 	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
-	/// <param name="maxTokenBytes">
-	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
-	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
-	/// </param>
 	internal StreamTokenizer(Buffer<T> buffer, Tokenizer<T> tok)
 	{
 		this.tok = tok;
@@ -43,15 +81,23 @@ public ref struct StreamTokenizer<T> where T : struct
 
 public static class StreamExtensions
 {
-	public static void SetStream(ref this StreamTokenizer<byte> stok, Stream stream)
+	/// <summary>
+	/// Resets an existing tokenizer with a new stream. You might choose this as an optimization, as it will re-use a buffer, avoiding allocations.
+	/// </summary>
+	/// <param name="stream">The new stream</param>
+	public static void SetStream(ref this StreamTokenizer<byte> tokenizer, Stream stream)
 	{
-		stok.tok.SetText([]);
-		stok.buffer.SetRead(stream.Read);
+		tokenizer.tok.SetText([]);
+		tokenizer.buffer.SetRead(stream.Read);
 	}
 
-	public static void SetStream(ref this StreamTokenizer<char> stok, TextReader stream)
+	/// <summary>
+	/// Resets an existing tokenizer with a new stream. You might choose this as an optimization, as it will re-use a buffer, avoiding allocations.
+	/// </summary>
+	/// <param name="stream">The new stream</param>
+	public static void SetStream(ref this StreamTokenizer<char> tokenizer, TextReader stream)
 	{
-		stok.tok.SetText([]);
-		stok.buffer.SetRead(stream.Read);
+		tokenizer.tok.SetText([]);
+		tokenizer.buffer.SetRead(stream.Read);
 	}
 }

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -1,15 +1,13 @@
 namespace uax29;
 
-using System.ComponentModel;
-
 public enum TokenType
 {
 	Words, Graphemes, Sentences
 }
 
-public delegate int Split<TSpan>(ReadOnlySpan<TSpan> input, bool atEOF = true);
+internal delegate int Split<TSpan>(ReadOnlySpan<TSpan> input, bool atEOF = true);
 
-public static class Tokenizer
+public static partial class Tokenizer
 {
 	/// <summary>
 	/// Create a tokenizer for a string, to split words, graphemes or sentences.
@@ -51,47 +49,6 @@ public static class Tokenizer
 	{
 		var split = charSplits[tokenType];
 		return new Tokenizer<char>(input, split);
-	}
-
-	/// <summary>
-	/// Create a tokenizer for a stream of UTF-8 encoded bytes, to split words, graphemes or sentences.
-	/// </summary>
-	/// <param name="stream">The stream of UTF-8 bytes to tokenize.</param>
-	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
-	/// <param name="maxTokenBytes">
-	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
-	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
-	/// </param>
-	/// <returns>
-	/// An enumerator of tokens. Use foreach (var token in tokens).
-	/// </returns>
-	/// 
-	public static StreamTokenizer<byte> Create(Stream stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
-	{
-		var tok = Create(ReadOnlySpan<byte>.Empty, tokenType);
-		var buffer = new Buffer<byte>(stream.Read, maxTokenBytes);
-		return new StreamTokenizer<byte>(buffer, tok);
-	}
-
-	/// <summary>
-	/// Create a tokenizer for a stream reader of char, to split words, graphemes or sentences.
-	/// </summary>
-	/// <param name="stream">The stream reader of char to tokenize.</param>
-	/// <param name="tokenType">Optional, choose to tokenize words, graphemes or sentences. Default is words.</param>
-	/// <param name="maxTokenBytes">
-	/// Optional, the maximum token size in bytes. Tokens that exceed this size will simply be cut off at this length, no error will occur.
-	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
-	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
-	/// </param>
-	/// <returns>
-	/// An enumerator of tokens. Use foreach (var token in tokens).
-	/// </returns>
-	public static StreamTokenizer<char> Create(TextReader stream, TokenType tokenType = TokenType.Words, int maxTokenBytes = 1024)
-	{
-		var tok = Create(ReadOnlySpan<char>.Empty, tokenType);
-		var buffer = new Buffer<char>(stream.Read, maxTokenBytes);
-		return new StreamTokenizer<char>(buffer, tok);
 	}
 
 	static readonly Dictionary<TokenType, Split<byte>> byteSplits = new()


### PR DESCRIPTION
An optimization for the backing buffer of stream tokenizer. Start & end both move, creating a window into the backing store. When the window comprises less than half of the total size, move remaining to the front of the array & read to fill.