### PR TITLE
Remove some indirections

### DIFF
--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -4,12 +4,12 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using uax29;
 
-var summary = BenchmarkRunner.Run<Benchmark>();
+//var summary = BenchmarkRunner.Run<Benchmark>();
 
-//var benchmark = new Benchmark();
-//benchmark.Setup();
-//var throughput = benchmark.Throughput();
-//Console.WriteLine($"Throughput: {Math.Round(throughput, 1)} MB/s");
+var benchmark = new Benchmark();
+benchmark.Setup();
+var throughput = benchmark.Throughput();
+Console.WriteLine($"Throughput: {Math.Round(throughput, 1)} MB/s");
 
 [MemoryDiagnoser]
 public class Benchmark

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -6,10 +6,10 @@ using uax29;
 
 var summary = BenchmarkRunner.Run<Benchmark>();
 
-// var benchmark = new Benchmark();
-// benchmark.Setup();
-// var throughput = benchmark.Throughput();
-// Console.WriteLine($"Throughput: {Math.Round(throughput, 1)} MB/s");
+//var benchmark = new Benchmark();
+//benchmark.Setup();
+//var throughput = benchmark.Throughput();
+//Console.WriteLine($"Throughput: {Math.Round(throughput, 1)} MB/s");
 
 [MemoryDiagnoser]
 public class Benchmark
@@ -23,7 +23,7 @@ public class Benchmark
 	[GlobalSetup]
 	public void Setup()
 	{
-		sample = File.ReadAllBytes("/Users/msherman/Documents/code/src/github.com/clipperhouse/uax29.net/Benchmarks/sample.txt");
+		sample = File.ReadAllBytes(@"C:\Users\kevin\source\repos\uax29.net\Benchmarks\sample.txt");
 		sampleStr = Encoding.UTF8.GetString(sample);
 		sampleStream = new MemoryStream(sample);
 	}

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -4,12 +4,12 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using uax29;
 
-//var summary = BenchmarkRunner.Run<Benchmark>();
+var summary = BenchmarkRunner.Run<Benchmark>();
 
-var benchmark = new Benchmark();
-benchmark.Setup();
-var throughput = benchmark.Throughput();
-Console.WriteLine($"Throughput: {Math.Round(throughput, 1)} MB/s");
+//var benchmark = new Benchmark();
+//benchmark.Setup();
+//var throughput = benchmark.Throughput();
+//Console.WriteLine($"Throughput: {Math.Round(throughput, 1)} MB/s");
 
 [MemoryDiagnoser]
 public class Benchmark
@@ -17,8 +17,6 @@ public class Benchmark
 	static byte[] sample = [];
 	static string sampleStr = "";
 	Stream sampleStream = Stream.Null;
-
-	private static readonly TokenType tokenType = TokenType.Words;
 
 	[GlobalSetup]
 	public void Setup()
@@ -31,7 +29,7 @@ public class Benchmark
 	[Benchmark]
 	public void TokenizeBytes()
 	{
-		var tokens = Tokenizer.Create(sample, tokenType);
+		var tokens = Tokenizer.Words.Create(sample);
 		foreach (var token in tokens)
 		{
 		}
@@ -40,7 +38,7 @@ public class Benchmark
 	[Benchmark]
 	public void TokenizeString()
 	{
-		var tokens = Tokenizer.Create(sampleStr, tokenType);
+		var tokens = Tokenizer.Words.Create(sampleStr);
 		foreach (var token in tokens)
 		{
 		}
@@ -51,7 +49,7 @@ public class Benchmark
 	public void TokenizeStream()
 	{
 		var stream = new MemoryStream(sample);
-		var tokens = Tokenizer.Create(stream, tokenType);
+		var tokens = Tokenizer.Words.Create(stream);
 		foreach (var token in tokens)
 		{
 		}
@@ -63,7 +61,7 @@ public class Benchmark
 		// This is to test to observe allocations.
 
 		// The creation will allocate a buffer of 1024 bytes
-		var tokens = Tokenizer.Create(sampleStream, tokenType);
+		var tokens = Tokenizer.Words.Create(sampleStream);
 
 		var runs = 10;
 		// keep in mind the 10 runs when interpreting the benchmark
@@ -90,7 +88,7 @@ public class Benchmark
 	[Benchmark]
 	public void TokenizerGraphemes()
 	{
-		var tokens = Tokenizer.Create(sample, TokenType.Graphemes);
+		var tokens = Tokenizer.Graphemes.Create(sample);
 		foreach (var token in tokens)
 		{
 		}
@@ -103,7 +101,7 @@ public class Benchmark
 		// warmup
 		for (var i = 0; i < runs; i++)
 		{
-			var tokens = Tokenizer.Create(sample, tokenType);
+			var tokens = Tokenizer.Words.Create(sample);
 			foreach (var token in tokens)
 			{
 
@@ -116,7 +114,7 @@ public class Benchmark
 
 		for (var i = 0; i < runs; i++)
 		{
-			var tokens = Tokenizer.Create(sample, tokenType);
+			var tokens = Tokenizer.Words.Create(sample);
 			foreach (var token in tokens)
 			{
 

--- a/uax29/Decoder.cs
+++ b/uax29/Decoder.cs
@@ -1,0 +1,54 @@
+namespace uax29;
+
+using System.Buffers;
+using System.Text;
+
+/// A bitmap of Unicode categories
+using Property = uint;
+
+internal interface IDecoder<TSpan>
+{
+	static abstract Property Ignore { get; }
+	static abstract Dict Dict { get; }
+
+	static abstract OperationStatus DecodeLastRune(ReadOnlySpan<TSpan> input, out Rune result, out int consumed);
+	static abstract OperationStatus DecodeFirstRune(ReadOnlySpan<TSpan> input, out Rune result, out int consumed);
+}
+
+internal interface IDictAndIgnore
+{
+	static abstract Dict Dict { get; }
+	static abstract Property Ignore { get; }
+}
+
+internal readonly struct Utf8Decoder<TDictAndIgnore> : IDecoder<byte>
+	where TDictAndIgnore : struct, IDictAndIgnore  // for non-ref for devirtualization purposes
+{
+	static Property IDecoder<byte>.Ignore
+	=> TDictAndIgnore.Ignore;
+
+	static Dict IDecoder<byte>.Dict
+	=> TDictAndIgnore.Dict;
+
+	static OperationStatus IDecoder<byte>.DecodeFirstRune(ReadOnlySpan<byte> input, out Rune result, out int consumed)
+	=> Rune.DecodeFromUtf8(input, out result, out consumed);
+
+	static OperationStatus IDecoder<byte>.DecodeLastRune(ReadOnlySpan<byte> input, out Rune result, out int consumed)
+	=> Rune.DecodeLastFromUtf8(input, out result, out consumed);
+}
+
+internal readonly struct Utf16Decoder<TDictAndIgnore> : IDecoder<char>
+	where TDictAndIgnore : struct, IDictAndIgnore  // for non-ref for devirtualization purposes
+{
+	static Property IDecoder<char>.Ignore
+	=> TDictAndIgnore.Ignore;
+
+	static Dict IDecoder<char>.Dict
+	=> TDictAndIgnore.Dict;
+
+	static OperationStatus IDecoder<char>.DecodeFirstRune(ReadOnlySpan<char> input, out Rune result, out int consumed)
+	=> Rune.DecodeFromUtf16(input, out result, out consumed);
+
+	static OperationStatus IDecoder<char>.DecodeLastRune(ReadOnlySpan<char> input, out Rune result, out int consumed)
+	=> Rune.DecodeLastFromUtf16(input, out result, out consumed);
+}

--- a/uax29/Decoder.cs
+++ b/uax29/Decoder.cs
@@ -8,28 +8,22 @@ using Property = uint;
 
 internal interface IDecoder<TSpan>
 {
-	static abstract Property Ignore { get; }
-	static abstract Dict Dict { get; }
-
 	static abstract OperationStatus DecodeLastRune(ReadOnlySpan<TSpan> input, out Rune result, out int consumed);
 	static abstract OperationStatus DecodeFirstRune(ReadOnlySpan<TSpan> input, out Rune result, out int consumed);
 }
 
-internal interface IDictAndIgnore
+internal interface IDict
 {
 	static abstract Dict Dict { get; }
+}
+
+internal interface IIgnore
+{
 	static abstract Property Ignore { get; }
 }
 
-internal readonly struct Utf8Decoder<TDictAndIgnore> : IDecoder<byte>
-	where TDictAndIgnore : struct, IDictAndIgnore  // for non-ref for devirtualization purposes
+internal readonly struct Utf8Decoder : IDecoder<byte>
 {
-	static Property IDecoder<byte>.Ignore
-	=> TDictAndIgnore.Ignore;
-
-	static Dict IDecoder<byte>.Dict
-	=> TDictAndIgnore.Dict;
-
 	static OperationStatus IDecoder<byte>.DecodeFirstRune(ReadOnlySpan<byte> input, out Rune result, out int consumed)
 	=> Rune.DecodeFromUtf8(input, out result, out consumed);
 
@@ -37,15 +31,8 @@ internal readonly struct Utf8Decoder<TDictAndIgnore> : IDecoder<byte>
 	=> Rune.DecodeLastFromUtf8(input, out result, out consumed);
 }
 
-internal readonly struct Utf16Decoder<TDictAndIgnore> : IDecoder<char>
-	where TDictAndIgnore : struct, IDictAndIgnore  // for non-ref for devirtualization purposes
+internal readonly struct Utf16Decoder : IDecoder<char>
 {
-	static Property IDecoder<char>.Ignore
-	=> TDictAndIgnore.Ignore;
-
-	static Dict IDecoder<char>.Dict
-	=> TDictAndIgnore.Dict;
-
 	static OperationStatus IDecoder<char>.DecodeFirstRune(ReadOnlySpan<char> input, out Rune result, out int consumed)
 	=> Rune.DecodeFromUtf16(input, out result, out consumed);
 

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace uax29;
 
 using System.Buffers;
@@ -7,207 +7,214 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
+/// Make SplitterBase helpers available
+using static SplitterBase;
+
 internal static partial class Graphemes
 {
-    internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
-    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeLastFromUtf16).Split;
+	private readonly struct GraphemesIgnore : IDictAndIgnore
+	{
+		static Dict IDictAndIgnore.Dict { get; } = Graphemes.Dict;
+		static Property IDictAndIgnore.Ignore { get; } = Extend;
+	}
 
-    internal class Splitter<TSpan> : SplitterBase<TSpan>
-    {
-        internal Splitter(Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune) :
-            base(Graphemes.Dict, Ignore, decodeFirstRune, decodeLastRune)
-        { }
+	internal static readonly Split<byte> SplitUtf8Bytes = Splitter<byte, Utf8Decoder<GraphemesIgnore>>.Split;
+	internal static readonly Split<char> SplitChars = Splitter<char, Utf16Decoder<GraphemesIgnore>>.Split;
 
-        new const Property Ignore = Extend;
+	internal sealed class Splitter<TSpan, TDecoder>
+		where TDecoder : struct, IDecoder<TSpan>
+	{
+		internal Splitter() : base()
+		{ }
 
-        public override int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
-        {
-            if (input.Length == 0)
-            {
-                return 0;
-            }
+		public static int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
+		{
+			if (input.Length == 0)
+			{
+				return 0;
+			}
 
-            // These vars are stateful across loop iterations
-            var pos = 0;
-            var w = 0;
-            Property current = 0;
+			// These vars are stateful across loop iterations
+			var pos = 0;
+			var w = 0;
+			Property current = 0;
 
-            while (true)
-            {
-                var sot = pos == 0;             // "start of text"
-                var eot = pos == input.Length;   // "end of text"
+			while (true)
+			{
+				var sot = pos == 0;             // "start of text"
+				var eot = pos == input.Length;   // "end of text"
 
 
-                if (eot)
-                {
-                    if (!atEOF)
-                    {
-                        // Token extends past current data, request more
-                        return 0; // TODO
-                    }
+				if (eot)
+				{
+					if (!atEOF)
+					{
+						// Token extends past current data, request more
+						return 0; // TODO
+					}
 
-                    // https://unicode.org/reports/tr29/#GB2
-                    break;
-                }
+					// https://unicode.org/reports/tr29/#GB2
+					break;
+				}
 
-                /*
+				/*
                     We've switched the evaluation order of GB1↓ and GB2↑. It's ok:
                     because we've checked for len(data) at the top of this function,
                     sot and eot are mutually exclusive, order doesn't matter.
                 */
 
-                var last = current;
-                var lastWidth = w;
+				var last = current;
+				var lastWidth = w;
 
-                // Rules are usually of the form Cat1 × Cat2; "current" refers to the first property
-                // to the right of the × or ÷, from which we look back or forward
+				// Rules are usually of the form Cat1 × Cat2; "current" refers to the first property
+				// to the right of the × or ÷, from which we look back or forward
 
-                var status = DecodeFirstRune(input[pos..], out Rune rune, out w);
-                if (status != OperationStatus.Done)
-                {
-                    // Garbage in, garbage out
-                    pos += w;
-                    break;
-                }
-                if (w == 0)
-                {
-                    if (atEOF)
-                    {
-                        // Just return the bytes, we can't do anything with them
-                        pos = input.Length;
-                        break;
-                    }
-                    // Rune extends past current data, request more
-                    return 0;
-                }
+				var status = TDecoder.DecodeFirstRune(input[pos..], out Rune rune, out w);
+				if (status != OperationStatus.Done)
+				{
+					// Garbage in, garbage out
+					pos += w;
+					break;
+				}
+				if (w == 0)
+				{
+					if (atEOF)
+					{
+						// Just return the bytes, we can't do anything with them
+						pos = input.Length;
+						break;
+					}
+					// Rune extends past current data, request more
+					return 0;
+				}
 
-                current = Dict.Lookup(rune.Value);
+				current = Dict.Lookup(rune.Value);
 
-                // https://unicode.org/reports/tr29/#GB1
-                if (sot)
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB1
+				if (sot)
+				{
+					pos += w;
+					continue;
+				}
 
-                // Optimization: no rule can possibly apply
-                if ((current | last) == 0)  // i.e. both are zero
-                {
-                    break;
-                }
+				// Optimization: no rule can possibly apply
+				if ((current | last) == 0)  // i.e. both are zero
+				{
+					break;
+				}
 
-                // https://unicode.org/reports/tr29/#GB3
-                if (current.Is(LF) && last.Is(CR))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB3
+				if (current.Is(LF) && last.Is(CR))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB4
-                // https://unicode.org/reports/tr29/#GB5
-                if ((current | last).Is(Control | CR | LF))
-                {
-                    break;
-                }
+				// https://unicode.org/reports/tr29/#GB4
+				// https://unicode.org/reports/tr29/#GB5
+				if ((current | last).Is(Control | CR | LF))
+				{
+					break;
+				}
 
-                // https://unicode.org/reports/tr29/#GB6
-                if (current.Is(L | V | LV | LVT) && last.Is(L))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB6
+				if (current.Is(L | V | LV | LVT) && last.Is(L))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB7
-                if (current.Is(V | T) && last.Is(LV | V))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB7
+				if (current.Is(V | T) && last.Is(LV | V))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB8
-                if (current.Is(T) && last.Is(LVT | T))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB8
+				if (current.Is(T) && last.Is(LVT | T))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB9
-                if (current.Is(Extend | ZWJ))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB9
+				if (current.Is(Extend | ZWJ))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB9a
-                if (current.Is(SpacingMark))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB9a
+				if (current.Is(SpacingMark))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB9b
-                if (last.Is(Prepend))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB9b
+				if (last.Is(Prepend))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#GB11
-                if (current.Is(Extended_Pictographic) && last.Is(ZWJ) && Previous(Extended_Pictographic, input[..(pos - lastWidth)]))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#GB11
+				if (current.Is(Extended_Pictographic) && last.Is(ZWJ) && Previous<TSpan, TDecoder>(Extended_Pictographic, input[..(pos - lastWidth)]))
+				{
+					pos += w;
+					continue;
+				}
 
 
-                // https://unicode.org/reports/tr29/#GB12 and
-                // https://unicode.org/reports/tr29/#GB13
-                if ((current & last).Is(Regional_Indicator))
-                {
-                    var i = pos;
-                    var count = 0;
+				// https://unicode.org/reports/tr29/#GB12 and
+				// https://unicode.org/reports/tr29/#GB13
+				if ((current & last).Is(Regional_Indicator))
+				{
+					var i = pos;
+					var count = 0;
 
-                    while (i > 0)
-                    {
-                        status = DecodeLastRune(input[..i], out Rune rune2, out int w2);
-                        if (status != OperationStatus.Done)
-                        {
-                            // Garbage in, garbage out
-                            break;
-                        }
-                        if (w2 == 0)
-                        {
-                            break;
-                        }
+					while (i > 0)
+					{
+						status = TDecoder.DecodeLastRune(input[..i], out Rune rune2, out int w2);
+						if (status != OperationStatus.Done)
+						{
+							// Garbage in, garbage out
+							break;
+						}
+						if (w2 == 0)
+						{
+							break;
+						}
 
-                        i -= w2;
+						i -= w2;
 
-                        var lookup = Dict.Lookup(rune2.Value);
+						var lookup = Dict.Lookup(rune2.Value);
 
-                        if (!lookup.Is(Regional_Indicator))
-                        {
-                            // It's GB13
-                            break;
-                        }
+						if (!lookup.Is(Regional_Indicator))
+						{
+							// It's GB13
+							break;
+						}
 
-                        count++;
-                    }
+						count++;
+					}
 
-                    // If i == 0, we fell through and hit sot (start of text), so GB12 applies
-                    // If i > 0, we hit a non-RI, so GB13 applies
-                    var odd = count % 2 == 1;
-                    if (odd)
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
+					// If i == 0, we fell through and hit sot (start of text), so GB12 applies
+					// If i > 0, we hit a non-RI, so GB13 applies
+					var odd = count % 2 == 1;
+					if (odd)
+					{
+						pos += w;
+						continue;
+					}
+				}
 
-                // If we fall through all the above rules, it's a grapheme cluster break
-                break;
-            }
+				// If we fall through all the above rules, it's a grapheme cluster break
+				break;
+			}
 
-            return pos;
-        }
-    }
+			return pos;
+		}
+	}
 }

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -19,15 +19,10 @@ internal static partial class Graphemes
 		static Dict IDict.Dict { get; } = Graphemes.Dict;
 	}
 
-	internal static readonly Split<byte> SplitUtf8Bytes = Splitter<byte, Utf8Decoder, GraphemesDict, GraphemesIgnore>.Split;
-	internal static readonly Split<char> SplitChars = Splitter<char, Utf16Decoder, GraphemesDict, GraphemesIgnore>.Split;
-
-	internal sealed class Splitter<TSpan, TDecoder, TDict, TIgnore>
+	internal sealed class Splitter<TSpan, TDecoder>
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
-		where TDict : struct, IDict // force non-reference so gets de-virtualized
-		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
-		private static SplitterBase.Context<TSpan, TDecoder, TDict, TIgnore> ctx { get; } = default;
+		private static SplitterBase.Context<TSpan, TDecoder, GraphemesDict, GraphemesIgnore> ctx { get; } = default;
 
 		internal Splitter() : base()
 		{ }

--- a/uax29/Graphemes.Splitter.cs
+++ b/uax29/Graphemes.Splitter.cs
@@ -7,10 +7,6 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
-/// Make SplitterBase helpers available
-using static SplitterBase;
-using static uax29.Sentences;
-
 internal static partial class Graphemes
 {
 	private readonly struct GraphemesIgnore : IIgnore
@@ -31,6 +27,8 @@ internal static partial class Graphemes
 		where TDict : struct, IDict // force non-reference so gets de-virtualized
 		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
+		private static SplitterBase.Context<TSpan, TDecoder, TDict, TIgnore> ctx { get; } = default;
+
 		internal Splitter() : base()
 		{ }
 
@@ -167,7 +165,7 @@ internal static partial class Graphemes
 				}
 
 				// https://unicode.org/reports/tr29/#GB11
-				if (current.Is(Extended_Pictographic) && last.Is(ZWJ) && Previous<TSpan, TDecoder, TDict, TIgnore>(Extended_Pictographic, input[..(pos - lastWidth)]))
+				if (current.Is(Extended_Pictographic) && last.Is(ZWJ) && ctx.Previous(Extended_Pictographic, input[..(pos - lastWidth)]))
 				{
 					pos += w;
 					continue;

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -10,7 +10,7 @@ internal static partial class Sentences
 {
 	private readonly struct SentencesIgnore : IIgnore
 	{
-		static Property IIgnore.Ignore { get; } = Extend | Format;
+		public static Property Ignore { get; } = Extend | Format;
 	}
 
 	private readonly struct SentencesDict : IDict
@@ -18,15 +18,10 @@ internal static partial class Sentences
 		static Dict IDict.Dict { get; } = Sentences.Dict;
 	}
 
-	internal static readonly Split<byte> SplitUtf8Bytes = Splitter<byte, Utf8Decoder, SentencesDict, SentencesIgnore>.Split;
-	internal static readonly Split<char> SplitChars = Splitter<char, Utf16Decoder, SentencesDict, SentencesIgnore>.Split;
-
-	internal sealed class Splitter<TSpan, TDecoder, TDict, TIgnore>
+	internal sealed class Splitter<TSpan, TDecoder>
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
-		where TDict : struct, IDict // force non-reference so gets de-virtualized
-		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
-		private static SplitterBase.Context<TSpan, TDecoder, TDict, TIgnore> ctx { get; } = default;
+		private static SplitterBase.Context<TSpan, TDecoder, SentencesDict, SentencesIgnore> ctx { get; } = default;
 
 		internal Splitter() : base()
 		{ }
@@ -136,7 +131,7 @@ internal static partial class Sentences
 				// The previous/subsequent methods are shorthand for "seek a property but skip over Extend & Format on the way"
 
 				// Optimization: determine if SB6 can possibly apply
-				var maybeSB6 = (current.Is(Numeric) && last.Is(ATerm | TIgnore.Ignore));
+				var maybeSB6 = (current.Is(Numeric) && last.Is(ATerm | SentencesIgnore.Ignore));
 
 				// https://unicode.org/reports/tr29/#SB6
 				if (maybeSB6)
@@ -149,7 +144,7 @@ internal static partial class Sentences
 				}
 
 				// Optimization: determine if SB7 can possibly apply
-				var maybeSB7 = current.Is(Upper) && last.Is(ATerm | TIgnore.Ignore);
+				var maybeSB7 = current.Is(Upper) && last.Is(ATerm | SentencesIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#SB7
 				if (maybeSB7)
@@ -163,7 +158,7 @@ internal static partial class Sentences
 				}
 
 				// Optimization: determine if SB8 can possibly apply
-				var maybeSB8 = last.Is(ATerm | Close | Sp | TIgnore.Ignore);
+				var maybeSB8 = last.Is(ATerm | Close | Sp | SentencesIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#SB8
 				if (maybeSB8)
@@ -241,7 +236,7 @@ internal static partial class Sentences
 				}
 
 				// Optimization: determine if SB8a can possibly apply
-				var maybeSB8a = current.Is(SContinue | SATerm) && last.Is(SATerm | Close | Sp | TIgnore.Ignore);
+				var maybeSB8a = current.Is(SContinue | SATerm) && last.Is(SATerm | Close | Sp | SentencesIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#SB8a
 				if (maybeSB8a)
@@ -282,7 +277,7 @@ internal static partial class Sentences
 				}
 
 				// Optimization: determine if SB9 can possibly apply
-				var maybeSB9 = current.Is(Close | Sp | ParaSep) && last.Is(SATerm | Close | TIgnore.Ignore);
+				var maybeSB9 = current.Is(Close | Sp | ParaSep) && last.Is(SATerm | Close | SentencesIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#SB9
 				if (maybeSB9)
@@ -311,7 +306,7 @@ internal static partial class Sentences
 				}
 
 				// Optimization: determine if SB10 can possibly apply
-				var maybeSB10 = current.Is(Sp | ParaSep) && last.Is(SATerm | Close | Sp | TIgnore.Ignore);
+				var maybeSB10 = current.Is(Sp | ParaSep) && last.Is(SATerm | Close | Sp | SentencesIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#SB10
 				if (maybeSB10)
@@ -352,7 +347,7 @@ internal static partial class Sentences
 				}
 
 				// Optimization: determine if SB11 can possibly apply
-				var maybeSB11 = last.Is(SATerm | Close | Sp | ParaSep | TIgnore.Ignore);
+				var maybeSB11 = last.Is(SATerm | Close | Sp | ParaSep | SentencesIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#SB11
 				if (maybeSB11)

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -6,9 +6,6 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
-/// Make SplitterBase helpers available
-using static SplitterBase;
-
 internal static partial class Sentences
 {
 	private readonly struct SentencesIgnore : IIgnore
@@ -29,6 +26,8 @@ internal static partial class Sentences
 		where TDict : struct, IDict // force non-reference so gets de-virtualized
 		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
+		private static SplitterBase.Context<TSpan, TDecoder, TDict, TIgnore> ctx { get; } = default;
+
 		internal Splitter() : base()
 		{ }
 
@@ -142,7 +141,7 @@ internal static partial class Sentences
 				// https://unicode.org/reports/tr29/#SB6
 				if (maybeSB6)
 				{
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(ATerm, input[..pos]))
+					if (ctx.Previous(ATerm, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -155,8 +154,8 @@ internal static partial class Sentences
 				// https://unicode.org/reports/tr29/#SB7
 				if (maybeSB7)
 				{
-					var pi = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(ATerm, input[..pos]);
-					if (pi >= 0 && Previous<TSpan, TDecoder, TDict, TIgnore>(Upper | Lower, input[..pi]))
+					var pi = ctx.PreviousIndex(ATerm, input[..pos]);
+					if (pi >= 0 && ctx.Previous(Upper | Lower, input[..pi]))
 					{
 						pos += w;
 						continue;
@@ -203,7 +202,7 @@ internal static partial class Sentences
 						p += w2;
 					}
 
-					if (Subsequent<TSpan, TDecoder, TDict, TIgnore>(Lower, input[p..]))
+					if (ctx.Subsequent(Lower, input[p..]))
 					{
 						var p2 = pos;
 
@@ -211,7 +210,7 @@ internal static partial class Sentences
 						var sp = pos;
 						while (true)
 						{
-							sp = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Sp, input[..sp]);
+							sp = ctx.PreviousIndex(Sp, input[..sp]);
 							if (sp < 0)
 							{
 								break;
@@ -223,7 +222,7 @@ internal static partial class Sentences
 						var close = p2;
 						while (true)
 						{
-							close = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Close, input[..close]);
+							close = ctx.PreviousIndex(Close, input[..close]);
 							if (close < 0)
 							{
 								break;
@@ -233,7 +232,7 @@ internal static partial class Sentences
 
 						// Having looked back past Sp's, Close's, and intervening Extend|Format,
 						// is there an ATerm?
-						if (Previous<TSpan, TDecoder, TDict, TIgnore>(ATerm, input[..p2]))
+						if (ctx.Previous(ATerm, input[..p2]))
 						{
 							pos += w;
 							continue;
@@ -253,7 +252,7 @@ internal static partial class Sentences
 					var sp = p;
 					while (true)
 					{
-						sp = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Sp, input[..sp]);
+						sp = ctx.PreviousIndex(Sp, input[..sp]);
 						if (sp < 0)
 						{
 							break;
@@ -265,7 +264,7 @@ internal static partial class Sentences
 					var close = p;
 					while (true)
 					{
-						close = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Close, input[..close]);
+						close = ctx.PreviousIndex(Close, input[..close]);
 						if (close < 0)
 						{
 							break;
@@ -275,7 +274,7 @@ internal static partial class Sentences
 
 					// Having looked back past Sp, Close, and intervening Extend|Format,
 					// is there an SATerm?
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(SATerm, input[..p]))
+					if (ctx.Previous(SATerm, input[..p]))
 					{
 						pos += w;
 						continue;
@@ -294,7 +293,7 @@ internal static partial class Sentences
 					var close = p;
 					while (true)
 					{
-						close = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Close, input[..close]);
+						close = ctx.PreviousIndex(Close, input[..close]);
 						if (close < 0)
 						{
 							break;
@@ -304,7 +303,7 @@ internal static partial class Sentences
 
 					// Having looked back past Close's and intervening Extend|Format,
 					// is there an SATerm?
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(SATerm, input[..p]))
+					if (ctx.Previous(SATerm, input[..p]))
 					{
 						pos += w;
 						continue;
@@ -323,7 +322,7 @@ internal static partial class Sentences
 					var sp = p;
 					while (true)
 					{
-						sp = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Sp, input[..sp]);
+						sp = ctx.PreviousIndex(Sp, input[..sp]);
 						if (sp < 0)
 						{
 							break;
@@ -335,7 +334,7 @@ internal static partial class Sentences
 					var close = p;
 					while (true)
 					{
-						close = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Close, input[..close]);
+						close = ctx.PreviousIndex(Close, input[..close]);
 						if (close < 0)
 						{
 							break;
@@ -345,7 +344,7 @@ internal static partial class Sentences
 
 					// Having looked back past Sp's, Close's, and intervening Extend|Format,
 					// is there an SATerm?
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(SATerm, input[..p]))
+					if (ctx.Previous(SATerm, input[..p]))
 					{
 						pos += w;
 						continue;
@@ -361,7 +360,7 @@ internal static partial class Sentences
 					var p = pos;
 
 					// Zero or one ParaSep
-					var ps = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(ParaSep, input[..p]);
+					var ps = ctx.PreviousIndex(ParaSep, input[..p]);
 					if (ps >= 0)
 					{
 						p = ps;
@@ -371,7 +370,7 @@ internal static partial class Sentences
 					var sp = p;
 					while (true)
 					{
-						sp = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Sp, input[..sp]);
+						sp = ctx.PreviousIndex(Sp, input[..sp]);
 						if (sp < 0)
 						{
 							break;
@@ -383,7 +382,7 @@ internal static partial class Sentences
 					var close = p;
 					while (true)
 					{
-						close = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Close, input[..close]);
+						close = ctx.PreviousIndex(Close, input[..close]);
 						if (close < 0)
 						{
 							break;
@@ -393,7 +392,7 @@ internal static partial class Sentences
 
 					// Having looked back past ParaSep, Sp's, Close's, and intervening Extend|Format,
 					// is there an SATerm?
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(SATerm, input[..p]))
+					if (ctx.Previous(SATerm, input[..p]))
 					{
 						break;
 					}

--- a/uax29/Sentences.Splitter.cs
+++ b/uax29/Sentences.Splitter.cs
@@ -1,4 +1,4 @@
-﻿namespace uax29;
+namespace uax29;
 
 using System.Buffers;
 using System.Text;
@@ -6,391 +6,399 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
+/// Make SplitterBase helpers available
+using static SplitterBase;
+
 internal static partial class Sentences
 {
-    internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
-    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeLastFromUtf16).Split;
+	private readonly struct SentencesIgnore : IDictAndIgnore
+	{
+		static Dict IDictAndIgnore.Dict { get; } = Sentences.Dict;
+		static Property IDictAndIgnore.Ignore { get; } = Extend | Format;
+	}
 
-    internal class Splitter<TSpan> : SplitterBase<TSpan>
-    {
-        internal Splitter(Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune) :
-            base(Sentences.Dict, Ignore, decodeFirstRune, decodeLastRune)
-        { }
+	internal static readonly Split<byte> SplitUtf8Bytes = Splitter<byte, Utf8Decoder<SentencesIgnore>>.Split;
+	internal static readonly Split<char> SplitChars = Splitter<char, Utf16Decoder<SentencesIgnore>>.Split;
 
-        const Property SATerm = STerm | ATerm;
-        const Property ParaSep = Sep | CR | LF;
-        new const Property Ignore = Extend | Format;
+	internal sealed class Splitter<TSpan, TDecoder>
+		where TDecoder : struct, IDecoder<TSpan>
+	{
+		internal Splitter() : base()
+		{ }
 
-        public override int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
-        {
-            if (input.Length == 0)
-            {
-                return 0;
-            }
+		const Property SATerm = STerm | ATerm;
+		const Property ParaSep = Sep | CR | LF;
 
-            // These vars are stateful across loop iterations
-            var pos = 0;
-            var w = 0;
-            Property current = 0;
+		public static int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
+		{
+			if (input.Length == 0)
+			{
+				return 0;
+			}
 
-            while (true)
-            {
-                var sot = pos == 0;             // "start of text"
-                var eot = pos == input.Length;   // "end of text"
+			// These vars are stateful across loop iterations
+			var pos = 0;
+			var w = 0;
+			Property current = 0;
 
-                if (eot)
-                {
-                    if (!atEOF)
-                    {
-                        // Token extends past current data, request more
-                        return 0; // TODO
-                    }
+			while (true)
+			{
+				var sot = pos == 0;             // "start of text"
+				var eot = pos == input.Length;   // "end of text"
 
-                    // https://unicode.org/reports/tr29/#SB2
-                    break;
-                }
+				if (eot)
+				{
+					if (!atEOF)
+					{
+						// Token extends past current data, request more
+						return 0; // TODO
+					}
+
+					// https://unicode.org/reports/tr29/#SB2
+					break;
+				}
 
 
-                /*
+				/*
                     We've switched the evaluation order of SB1↓ and SB2↑. It's ok:
                     because we've checked for len(data) at the top of this function,
                     sot and eot are mutually exclusive, order doesn't matter.
                 */
 
-                // Rules are usually of the form Cat1 × Cat2; "current" refers to the first property
-                // to the right of the ×, from which we look back or forward
+				// Rules are usually of the form Cat1 × Cat2; "current" refers to the first property
+				// to the right of the ×, from which we look back or forward
 
-                var last = current;
+				var last = current;
 
-                var status = DecodeFirstRune(input[pos..], out Rune rune, out w);
+				var status = TDecoder.DecodeFirstRune(input[pos..], out Rune rune, out w);
 
-                if (status != OperationStatus.Done)
-                {
-                    // Garbage in, garbage out
-                    pos += w;
-                    break;
-                }
-                if (w == 0)
-                {
-                    if (atEOF)
-                    {
-                        // Just return the bytes, we can't do anything with them
-                        pos = input.Length;
-                        break;
-                    }
-                    // Rune extends past current data, request more
-                    return 0;
-                }
+				if (status != OperationStatus.Done)
+				{
+					// Garbage in, garbage out
+					pos += w;
+					break;
+				}
+				if (w == 0)
+				{
+					if (atEOF)
+					{
+						// Just return the bytes, we can't do anything with them
+						pos = input.Length;
+						break;
+					}
+					// Rune extends past current data, request more
+					return 0;
+				}
 
-                current = Dict.Lookup(rune.Value);
+				current = Dict.Lookup(rune.Value);
 
-                // https://unicode.org/reports/tr29/#SB1
-                if (sot)
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#SB1
+				if (sot)
+				{
+					pos += w;
+					continue;
+				}
 
-                // Optimization: no rule can possibly apply
-                if ((current | last) == 0)  // i.e. both are zero
-                {
-                    pos += w;
-                    continue;
-                }
+				// Optimization: no rule can possibly apply
+				if ((current | last) == 0)  // i.e. both are zero
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#SB3
-                if (current.Is(LF) && last.Is(CR))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#SB3
+				if (current.Is(LF) && last.Is(CR))
+				{
+					pos += w;
+					continue;
+				}
 
-                // https://unicode.org/reports/tr29/#SB4
-                if (last.Is(ParaSep))
-                {
-                    break;
-                }
+				// https://unicode.org/reports/tr29/#SB4
+				if (last.Is(ParaSep))
+				{
+					break;
+				}
 
-                // https://unicode.org/reports/tr29/#SB5
-                if (current.Is(Extend | Format))
-                {
-                    pos += w;
-                    continue;
-                }
+				// https://unicode.org/reports/tr29/#SB5
+				if (current.Is(Extend | Format))
+				{
+					pos += w;
+					continue;
+				}
 
-                // SB5 applies to subsequent rules; there is an implied "ignoring Extend & Format"
-                // https://unicode.org/reports/tr29/#Grapheme_Cluster_and_Format_Rules
-                // The previous/subsequent methods are shorthand for "seek a property but skip over Extend & Format on the way"
+				// SB5 applies to subsequent rules; there is an implied "ignoring Extend & Format"
+				// https://unicode.org/reports/tr29/#Grapheme_Cluster_and_Format_Rules
+				// The previous/subsequent methods are shorthand for "seek a property but skip over Extend & Format on the way"
 
-                // Optimization: determine if SB6 can possibly apply
-                var maybeSB6 = (current.Is(Numeric) && last.Is(ATerm | Ignore));
+				// Optimization: determine if SB6 can possibly apply
+				var maybeSB6 = (current.Is(Numeric) && last.Is(ATerm | TDecoder.Ignore));
 
-                // https://unicode.org/reports/tr29/#SB6
-                if (maybeSB6)
-                {
-                    if (Previous(ATerm, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
+				// https://unicode.org/reports/tr29/#SB6
+				if (maybeSB6)
+				{
+					if (Previous<TSpan, TDecoder>(ATerm, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
 
-                // Optimization: determine if SB7 can possibly apply
-                var maybeSB7 = current.Is(Upper) && last.Is(ATerm | Ignore);
+				// Optimization: determine if SB7 can possibly apply
+				var maybeSB7 = current.Is(Upper) && last.Is(ATerm | TDecoder.Ignore);
 
-                // https://unicode.org/reports/tr29/#SB7
-                if (maybeSB7)
-                {
-                    var pi = PreviousIndex(ATerm, input[..pos]);
-                    if (pi >= 0 && Previous(Upper | Lower, input[..pi]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
+				// https://unicode.org/reports/tr29/#SB7
+				if (maybeSB7)
+				{
+					var pi = PreviousIndex<TSpan, TDecoder>(ATerm, input[..pos]);
+					if (pi >= 0 && Previous<TSpan, TDecoder>(Upper | Lower, input[..pi]))
+					{
+						pos += w;
+						continue;
+					}
+				}
 
-                // Optimization: determine if SB8 can possibly apply
-                var maybeSB8 = last.Is(ATerm | Close | Sp | Ignore);
+				// Optimization: determine if SB8 can possibly apply
+				var maybeSB8 = last.Is(ATerm | Close | Sp | TDecoder.Ignore);
 
-                // https://unicode.org/reports/tr29/#SB8
-                if (maybeSB8)
-                {
-                    var p = pos;
+				// https://unicode.org/reports/tr29/#SB8
+				if (maybeSB8)
+				{
+					var p = pos;
 
-                    // ( ¬(OLetter | Upper | Lower | ParaSep | SATerm) )*
-                    // Zero or more of not-the-above properties
-                    while (p < input.Length)
-                    {
-                        status = DecodeFirstRune(input[p..], out Rune rune2, out int w2);
-                        if (status != OperationStatus.Done)
-                        {
-                            // Garbage in, garbage out
-                            break;
-                        }
-                        if (w2 == 0)
-                        {
-                            if (atEOF)
-                            {
-                                // Just return the bytes, we can't do anything with them
-                                pos = input.Length;
-                                goto getout;    // i'd prefer a labeled break, I guess that's not thing? 
-                            }
-                            // Rune extends past current data, request more
-                            return 0; // TODO
-                        }
+					// ( ¬(OLetter | Upper | Lower | ParaSep | SATerm) )*
+					// Zero or more of not-the-above properties
+					while (p < input.Length)
+					{
+						status = TDecoder.DecodeFirstRune(input[p..], out Rune rune2, out int w2);
+						if (status != OperationStatus.Done)
+						{
+							// Garbage in, garbage out
+							break;
+						}
+						if (w2 == 0)
+						{
+							if (atEOF)
+							{
+								// Just return the bytes, we can't do anything with them
+								pos = input.Length;
+								goto getout;    // i'd prefer a labeled break, I guess that's not thing? 
+							}
+							// Rune extends past current data, request more
+							return 0; // TODO
+						}
 
-                        var lookup = Dict.Lookup(rune2.Value);
+						var lookup = Dict.Lookup(rune2.Value);
 
-                        if (lookup.Is(OLetter | Upper | Lower | ParaSep | SATerm))
-                        {
-                            break;
-                        }
+						if (lookup.Is(OLetter | Upper | Lower | ParaSep | SATerm))
+						{
+							break;
+						}
 
-                        p += w2;
-                    }
+						p += w2;
+					}
 
-                    if (Subsequent(Lower, input[p..]))
-                    {
-                        var p2 = pos;
+					if (Subsequent<TSpan, TDecoder>(Lower, input[p..]))
+					{
+						var p2 = pos;
 
-                        // Zero or more Sp
-                        var sp = pos;
-                        while (true)
-                        {
-                            sp = PreviousIndex(Sp, input[..sp]);
-                            if (sp < 0)
-                            {
-                                break;
-                            }
-                            p2 = sp;
-                        }
+						// Zero or more Sp
+						var sp = pos;
+						while (true)
+						{
+							sp = PreviousIndex<TSpan, TDecoder>(Sp, input[..sp]);
+							if (sp < 0)
+							{
+								break;
+							}
+							p2 = sp;
+						}
 
-                        // Zero or more Close
-                        var close = p2;
-                        while (true)
-                        {
-                            close = PreviousIndex(Close, input[..close]);
-                            if (close < 0)
-                            {
-                                break;
-                            }
-                            p2 = close;
-                        }
+						// Zero or more Close
+						var close = p2;
+						while (true)
+						{
+							close = PreviousIndex<TSpan, TDecoder>(Close, input[..close]);
+							if (close < 0)
+							{
+								break;
+							}
+							p2 = close;
+						}
 
-                        // Having looked back past Sp's, Close's, and intervening Extend|Format,
-                        // is there an ATerm?
-                        if (Previous(ATerm, input[..p2]))
-                        {
-                            pos += w;
-                            continue;
-                        }
-                    }
-                }
+						// Having looked back past Sp's, Close's, and intervening Extend|Format,
+						// is there an ATerm?
+						if (Previous<TSpan, TDecoder>(ATerm, input[..p2]))
+						{
+							pos += w;
+							continue;
+						}
+					}
+				}
 
-                // Optimization: determine if SB8a can possibly apply
-                var maybeSB8a = current.Is(SContinue | SATerm) && last.Is(SATerm | Close | Sp | Ignore);
+				// Optimization: determine if SB8a can possibly apply
+				var maybeSB8a = current.Is(SContinue | SATerm) && last.Is(SATerm | Close | Sp | TDecoder.Ignore);
 
-                // https://unicode.org/reports/tr29/#SB8a
-                if (maybeSB8a)
-                {
-                    var p = pos;
+				// https://unicode.org/reports/tr29/#SB8a
+				if (maybeSB8a)
+				{
+					var p = pos;
 
-                    // Zero or more Sp
-                    var sp = p;
-                    while (true)
-                    {
-                        sp = PreviousIndex(Sp, input[..sp]);
-                        if (sp < 0)
-                        {
-                            break;
-                        }
-                        p = sp;
-                    }
+					// Zero or more Sp
+					var sp = p;
+					while (true)
+					{
+						sp = PreviousIndex<TSpan, TDecoder>(Sp, input[..sp]);
+						if (sp < 0)
+						{
+							break;
+						}
+						p = sp;
+					}
 
-                    // Zero or more Close
-                    var close = p;
-                    while (true)
-                    {
-                        close = PreviousIndex(Close, input[..close]);
-                        if (close < 0)
-                        {
-                            break;
-                        }
-                        p = close;
-                    }
+					// Zero or more Close
+					var close = p;
+					while (true)
+					{
+						close = PreviousIndex<TSpan, TDecoder>(Close, input[..close]);
+						if (close < 0)
+						{
+							break;
+						}
+						p = close;
+					}
 
-                    // Having looked back past Sp, Close, and intervening Extend|Format,
-                    // is there an SATerm?
-                    if (Previous(SATerm, input[..p]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
+					// Having looked back past Sp, Close, and intervening Extend|Format,
+					// is there an SATerm?
+					if (Previous<TSpan, TDecoder>(SATerm, input[..p]))
+					{
+						pos += w;
+						continue;
+					}
+				}
 
-                // Optimization: determine if SB9 can possibly apply
-                var maybeSB9 = current.Is(Close | Sp | ParaSep) && last.Is(SATerm | Close | Ignore);
+				// Optimization: determine if SB9 can possibly apply
+				var maybeSB9 = current.Is(Close | Sp | ParaSep) && last.Is(SATerm | Close | TDecoder.Ignore);
 
-                // https://unicode.org/reports/tr29/#SB9
-                if (maybeSB9)
-                {
-                    var p = pos;
+				// https://unicode.org/reports/tr29/#SB9
+				if (maybeSB9)
+				{
+					var p = pos;
 
-                    // Zero or more Close's
-                    var close = p;
-                    while (true)
-                    {
-                        close = PreviousIndex(Close, input[..close]);
-                        if (close < 0)
-                        {
-                            break;
-                        }
-                        p = close;
-                    }
+					// Zero or more Close's
+					var close = p;
+					while (true)
+					{
+						close = PreviousIndex<TSpan, TDecoder>(Close, input[..close]);
+						if (close < 0)
+						{
+							break;
+						}
+						p = close;
+					}
 
-                    // Having looked back past Close's and intervening Extend|Format,
-                    // is there an SATerm?
-                    if (Previous(SATerm, input[..p]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
+					// Having looked back past Close's and intervening Extend|Format,
+					// is there an SATerm?
+					if (Previous<TSpan, TDecoder>(SATerm, input[..p]))
+					{
+						pos += w;
+						continue;
+					}
+				}
 
-                // Optimization: determine if SB10 can possibly apply
-                var maybeSB10 = current.Is(Sp | ParaSep) && last.Is(SATerm | Close | Sp | Ignore);
+				// Optimization: determine if SB10 can possibly apply
+				var maybeSB10 = current.Is(Sp | ParaSep) && last.Is(SATerm | Close | Sp | TDecoder.Ignore);
 
-                // https://unicode.org/reports/tr29/#SB10
-                if (maybeSB10)
-                {
-                    var p = pos;
+				// https://unicode.org/reports/tr29/#SB10
+				if (maybeSB10)
+				{
+					var p = pos;
 
-                    // Zero or more Sp's
-                    var sp = p;
-                    while (true)
-                    {
-                        sp = PreviousIndex(Sp, input[..sp]);
-                        if (sp < 0)
-                        {
-                            break;
-                        }
-                        p = sp;
-                    }
+					// Zero or more Sp's
+					var sp = p;
+					while (true)
+					{
+						sp = PreviousIndex<TSpan, TDecoder>(Sp, input[..sp]);
+						if (sp < 0)
+						{
+							break;
+						}
+						p = sp;
+					}
 
-                    // Zero or more Close's
-                    var close = p;
-                    while (true)
-                    {
-                        close = PreviousIndex(Close, input[..close]);
-                        if (close < 0)
-                        {
-                            break;
-                        }
-                        p = close;
-                    }
+					// Zero or more Close's
+					var close = p;
+					while (true)
+					{
+						close = PreviousIndex<TSpan, TDecoder>(Close, input[..close]);
+						if (close < 0)
+						{
+							break;
+						}
+						p = close;
+					}
 
-                    // Having looked back past Sp's, Close's, and intervening Extend|Format,
-                    // is there an SATerm?
-                    if (Previous(SATerm, input[..p]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
+					// Having looked back past Sp's, Close's, and intervening Extend|Format,
+					// is there an SATerm?
+					if (Previous<TSpan, TDecoder>(SATerm, input[..p]))
+					{
+						pos += w;
+						continue;
+					}
+				}
 
-                // Optimization: determine if SB11 can possibly apply
-                var maybeSB11 = last.Is(SATerm | Close | Sp | ParaSep | Ignore);
+				// Optimization: determine if SB11 can possibly apply
+				var maybeSB11 = last.Is(SATerm | Close | Sp | ParaSep | TDecoder.Ignore);
 
-                // https://unicode.org/reports/tr29/#SB11
-                if (maybeSB11)
-                {
-                    var p = pos;
+				// https://unicode.org/reports/tr29/#SB11
+				if (maybeSB11)
+				{
+					var p = pos;
 
-                    // Zero or one ParaSep
-                    var ps = PreviousIndex(ParaSep, input[..p]);
-                    if (ps >= 0)
-                    {
-                        p = ps;
-                    }
+					// Zero or one ParaSep
+					var ps = PreviousIndex<TSpan, TDecoder>(ParaSep, input[..p]);
+					if (ps >= 0)
+					{
+						p = ps;
+					}
 
-                    // Zero or more Sp's
-                    var sp = p;
-                    while (true)
-                    {
-                        sp = PreviousIndex(Sp, input[..sp]);
-                        if (sp < 0)
-                        {
-                            break;
-                        }
-                        p = sp;
-                    }
+					// Zero or more Sp's
+					var sp = p;
+					while (true)
+					{
+						sp = PreviousIndex<TSpan, TDecoder>(Sp, input[..sp]);
+						if (sp < 0)
+						{
+							break;
+						}
+						p = sp;
+					}
 
-                    // Zero or more Close's
-                    var close = p;
-                    while (true)
-                    {
-                        close = PreviousIndex(Close, input[..close]);
-                        if (close < 0)
-                        {
-                            break;
-                        }
-                        p = close;
-                    }
+					// Zero or more Close's
+					var close = p;
+					while (true)
+					{
+						close = PreviousIndex<TSpan, TDecoder>(Close, input[..close]);
+						if (close < 0)
+						{
+							break;
+						}
+						p = close;
+					}
 
-                    // Having looked back past ParaSep, Sp's, Close's, and intervening Extend|Format,
-                    // is there an SATerm?
-                    if (Previous(SATerm, input[..p]))
-                    {
-                        break;
-                    }
-                }
+					// Having looked back past ParaSep, Sp's, Close's, and intervening Extend|Format,
+					// is there an SATerm?
+					if (Previous<TSpan, TDecoder>(SATerm, input[..p]))
+					{
+						break;
+					}
+				}
 
-                // https://unicode.org/reports/tr29/#SB998
-                pos += w;
-            }
+				// https://unicode.org/reports/tr29/#SB998
+				pos += w;
+			}
 
-        getout:
-            return pos;
-        }
-    }
+		getout:
+			return pos;
+		}
+	}
 }

--- a/uax29/Splitter.cs
+++ b/uax29/Splitter.cs
@@ -1,4 +1,4 @@
-﻿namespace uax29;
+namespace uax29;
 
 using System.Buffers;
 using System.Text;
@@ -6,141 +6,118 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
-internal delegate OperationStatus Decoder<TSpan>(ReadOnlySpan<TSpan> input, out Rune result, out int consumed);
-
-internal abstract class SplitterBase<TSpan>
+internal static class SplitterBase
 {
-    readonly internal Dict Dict;
-    readonly internal Property Ignore;
-    readonly internal Decoder<TSpan> DecodeFirstRune;
-    readonly internal Decoder<TSpan> DecodeLastRune;
+	/// <summary>
+	/// Seek backward until it hits a rune which matches property.
+	/// </summary>
+	/// <param name="property">Property to attempt to find</param>
+	/// <param name="input">Data in which to seek</param>
+	/// <returns>The index if found, or -1 if not</returns>
+	internal static int PreviousIndex<TSpan, TDecoder>(Property property, ReadOnlySpan<TSpan> input)
+		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+	{
+		// Start at the end of the buffer and move backwards
+		var i = input.Length;
+		while (i > 0)
+		{
+			var status = TDecoder.DecodeLastRune(input[..i], out Rune rune, out int w);
+			if (status != OperationStatus.Done)
+			{
+				// Garbage in, garbage out
+				break;
+			}
+			if (w == 0)
+			{
+				break;
+			}
 
-    public SplitterBase(Dict dict, Property ignore, Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune)
-    {
-        this.Dict = dict;
-        this.Ignore = ignore;
-        this.DecodeFirstRune = decodeFirstRune;
-        this.DecodeLastRune = decodeLastRune;
-    }
+			i -= w;
+			var lookup = TDecoder.Dict.Lookup(rune.Value);
 
-    /// <summary>
-    /// Reads input until a token break
-    /// </summary>
-    /// <param name="input">Data to split</param>
-    /// <param name="atEOF">
-    /// Indicates whether the current input is all that is coming.
-    /// (Always true in the current implementation, we may implement streaming in the future.)
-    /// </param>
-    /// <returns></returns>
-    public abstract int Split(ReadOnlySpan<TSpan> input, bool atEOF);
+			if (lookup.Is(TDecoder.Ignore))
+			{
+				continue;
+			}
 
-    /// <summary>
-    /// Seek backward until it hits a rune which matches property.
-    /// </summary>
-    /// <param name="property">Property to attempt to find</param>
-    /// <param name="input">Data in which to seek</param>
-    /// <returns>The index if found, or -1 if not</returns>
-    internal int PreviousIndex(Property property, ReadOnlySpan<TSpan> input)
-    {
-        // Start at the end of the buffer and move backwards
-        var i = input.Length;
-        while (i > 0)
-        {
-            var status = DecodeLastRune(input[..i], out Rune rune, out int w);
-            if (status != OperationStatus.Done)
-            {
-                // Garbage in, garbage out
-                break;
-            }
-            if (w == 0)
-            {
-                break;
-            }
+			if (lookup.Is(property))
+			{
+				return i;
+			}
 
-            i -= w;
-            var lookup = Dict.Lookup(rune.Value);
+			// If we get this far, it's not there
+			break;
+		}
 
-            if (lookup.Is(Ignore))
-            {
-                continue;
-            }
+		return -1;
+	}
 
-            if (lookup.Is(property))
-            {
-                return i;
-            }
+	/// <summary>
+	/// Seek backward until it hits a rune which matches property.
+	/// </summary>
+	/// <param name="property">Property to attempt to find</param>
+	/// <param name="input">Data in which to seek</param>
+	/// <returns>True if found, otherwise false</returns>
+	internal static bool Previous<TSpan, TDecoder>(Property property, ReadOnlySpan<TSpan> input)
+		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+	{
+		return PreviousIndex<TSpan, TDecoder>(property, input) != -1;
+	}
 
-            // If we get this far, it's not there
-            break;
-        }
+	/// <summary>
+	/// Seek forward until it hits a rune which matches property.
+	/// </summary>
+	/// <param name="property">Property to attempt to find</param>
+	/// <param name="input">Data in which to seek</param>
+	/// <returns>True if found, otherwise false</returns>
+	internal static bool Subsequent<TSpan, TDecoder>(Property property, ReadOnlySpan<TSpan> input)
+		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+	{
+		var i = 0;
+		while (i < input.Length)
+		{
+			var status = TDecoder.DecodeFirstRune(input[i..], out Rune rune, out int w);
+			if (status != OperationStatus.Done)
+			{
+				// Garbage in, garbage out
+				break;
+			}
+			if (w == 0)
+			{
+				break;
+			}
 
-        return -1;
-    }
+			var lookup = TDecoder.Dict.Lookup(rune.Value);
 
-    /// <summary>
-    /// Seek backward until it hits a rune which matches property.
-    /// </summary>
-    /// <param name="property">Property to attempt to find</param>
-    /// <param name="input">Data in which to seek</param>
-    /// <returns>True if found, otherwise false</returns>
-    internal bool Previous(Property property, ReadOnlySpan<TSpan> input)
-    {
-        return PreviousIndex(property, input) != -1;
-    }
+			if (lookup.Is(TDecoder.Ignore))
+			{
+				i += w;
+				continue;
+			}
 
-    /// <summary>
-    /// Seek forward until it hits a rune which matches property.
-    /// </summary>
-    /// <param name="property">Property to attempt to find</param>
-    /// <param name="input">Data in which to seek</param>
-    /// <returns>True if found, otherwise false</returns>
-    internal bool Subsequent(Property property, ReadOnlySpan<TSpan> input)
-    {
-        var i = 0;
-        while (i < input.Length)
-        {
-            var status = DecodeFirstRune(input[i..], out Rune rune, out int w);
-            if (status != OperationStatus.Done)
-            {
-                // Garbage in, garbage out
-                break;
-            }
-            if (w == 0)
-            {
-                break;
-            }
+			if (lookup.Is(property))
+			{
+				return true;
+			}
 
-            var lookup = Dict.Lookup(rune.Value);
+			// If we get this far, it's not there
+			break;
+		}
 
-            if (lookup.Is(Ignore))
-            {
-                i += w;
-                continue;
-            }
-
-            if (lookup.Is(property))
-            {
-                return true;
-            }
-
-            // If we get this far, it's not there
-            break;
-        }
-
-        return false;
-    }
+		return false;
+	}
 }
 
 internal static class Extensions
 {
-    /// <summary>
-    /// Determines whether two properties (bitstrings) match, i.e. intersect, i.e. share at least one bit.
-    /// </summary>
-    /// <param name="lookup">One property to test against...</param>
-    /// <param name="properties">...the other</param>
-    /// <returns>True if the two properties share a bit, i.e. Unicode category.</returns>
-    internal static bool Is(this Property lookup, Property properties)
-    {
-        return (lookup & properties) != 0;
-    }
+	/// <summary>
+	/// Determines whether two properties (bitstrings) match, i.e. intersect, i.e. share at least one bit.
+	/// </summary>
+	/// <param name="lookup">One property to test against...</param>
+	/// <param name="properties">...the other</param>
+	/// <returns>True if the two properties share a bit, i.e. Unicode category.</returns>
+	internal static bool Is(this Property lookup, Property properties)
+	{
+		return (lookup & properties) != 0;
+	}
 }

--- a/uax29/Splitter.cs
+++ b/uax29/Splitter.cs
@@ -9,12 +9,23 @@ using Property = uint;
 internal static class SplitterBase
 {
 	/// <summary>
+	/// Helper type to DRY up callsites w.r.t. generic arguments.
+	/// </summary>
+	internal readonly struct Context<TSpan, TDecoder, TDict, TIgnore>
+		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+		where TDict : struct, IDict // force non-reference so gets de-virtualized
+		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
+	{
+		// intentionally empty
+	}
+
+	/// <summary>
 	/// Seek backward until it hits a rune which matches property.
 	/// </summary>
 	/// <param name="property">Property to attempt to find</param>
 	/// <param name="input">Data in which to seek</param>
 	/// <returns>The index if found, or -1 if not</returns>
-	internal static int PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Property property, ReadOnlySpan<TSpan> input)
+	internal static int PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(this Context<TSpan, TDecoder, TDict, TIgnore> ctx, Property property, ReadOnlySpan<TSpan> input)
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
 		where TDict: struct, IDict // force non-reference so gets de-virtualized
 		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
@@ -60,12 +71,12 @@ internal static class SplitterBase
 	/// <param name="property">Property to attempt to find</param>
 	/// <param name="input">Data in which to seek</param>
 	/// <returns>True if found, otherwise false</returns>
-	internal static bool Previous<TSpan, TDecoder, TDict, TIgnore>(Property property, ReadOnlySpan<TSpan> input)
+	internal static bool Previous<TSpan, TDecoder, TDict, TIgnore>(this Context<TSpan, TDecoder, TDict, TIgnore> ctx, Property property, ReadOnlySpan<TSpan> input)
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
 		where TDict : struct, IDict // force non-reference so gets de-virtualized
 		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
-		return PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(property, input) != -1;
+		return ctx.PreviousIndex(property, input) != -1;
 	}
 
 	/// <summary>
@@ -74,7 +85,7 @@ internal static class SplitterBase
 	/// <param name="property">Property to attempt to find</param>
 	/// <param name="input">Data in which to seek</param>
 	/// <returns>True if found, otherwise false</returns>
-	internal static bool Subsequent<TSpan, TDecoder, TDict, TIgnore>(Property property, ReadOnlySpan<TSpan> input)
+	internal static bool Subsequent<TSpan, TDecoder, TDict, TIgnore>(this Context<TSpan, TDecoder, TDict, TIgnore> ctx, Property property, ReadOnlySpan<TSpan> input)
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
 		where TDict : struct, IDict // force non-reference so gets de-virtualized
 		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized

--- a/uax29/Splitter.cs
+++ b/uax29/Splitter.cs
@@ -14,8 +14,10 @@ internal static class SplitterBase
 	/// <param name="property">Property to attempt to find</param>
 	/// <param name="input">Data in which to seek</param>
 	/// <returns>The index if found, or -1 if not</returns>
-	internal static int PreviousIndex<TSpan, TDecoder>(Property property, ReadOnlySpan<TSpan> input)
+	internal static int PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Property property, ReadOnlySpan<TSpan> input)
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+		where TDict: struct, IDict // force non-reference so gets de-virtualized
+		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
 		// Start at the end of the buffer and move backwards
 		var i = input.Length;
@@ -33,9 +35,9 @@ internal static class SplitterBase
 			}
 
 			i -= w;
-			var lookup = TDecoder.Dict.Lookup(rune.Value);
+			var lookup = TDict.Dict.Lookup(rune.Value);
 
-			if (lookup.Is(TDecoder.Ignore))
+			if (lookup.Is(TIgnore.Ignore))
 			{
 				continue;
 			}
@@ -58,10 +60,12 @@ internal static class SplitterBase
 	/// <param name="property">Property to attempt to find</param>
 	/// <param name="input">Data in which to seek</param>
 	/// <returns>True if found, otherwise false</returns>
-	internal static bool Previous<TSpan, TDecoder>(Property property, ReadOnlySpan<TSpan> input)
+	internal static bool Previous<TSpan, TDecoder, TDict, TIgnore>(Property property, ReadOnlySpan<TSpan> input)
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+		where TDict : struct, IDict // force non-reference so gets de-virtualized
+		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
-		return PreviousIndex<TSpan, TDecoder>(property, input) != -1;
+		return PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(property, input) != -1;
 	}
 
 	/// <summary>
@@ -70,8 +74,10 @@ internal static class SplitterBase
 	/// <param name="property">Property to attempt to find</param>
 	/// <param name="input">Data in which to seek</param>
 	/// <returns>True if found, otherwise false</returns>
-	internal static bool Subsequent<TSpan, TDecoder>(Property property, ReadOnlySpan<TSpan> input)
+	internal static bool Subsequent<TSpan, TDecoder, TDict, TIgnore>(Property property, ReadOnlySpan<TSpan> input)
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
+		where TDict : struct, IDict // force non-reference so gets de-virtualized
+		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
 		var i = 0;
 		while (i < input.Length)
@@ -87,9 +93,9 @@ internal static class SplitterBase
 				break;
 			}
 
-			var lookup = TDecoder.Dict.Lookup(rune.Value);
+			var lookup = TDict.Dict.Lookup(rune.Value);
 
-			if (lookup.Is(TDecoder.Ignore))
+			if (lookup.Is(TIgnore.Ignore))
 			{
 				i += w;
 				continue;

--- a/uax29/StreamTokenizer.cs
+++ b/uax29/StreamTokenizer.cs
@@ -1,13 +1,15 @@
-﻿namespace uax29;
+namespace uax29;
 
 /// <summary>
 /// Tokenizer splits a stream of UTF-8 bytes as words, sentences or graphemes, per the Unicode UAX #29 spec.
 /// </summary>
-public ref struct StreamTokenizer<T> where T : struct
+public ref struct StreamTokenizer<TSpan, TSplit>
+	where TSpan : struct
+	where TSplit : struct, ISplit<TSpan>
 {
-	internal Tokenizer<T> tok;
+	internal Tokenizer<TSpan, TSplit> tok;
 
-	internal Buffer<T> buffer;
+	internal Buffer<TSpan> buffer;
 
 	/// <summary>
 	/// Tokenizer splits strings (or UTF-8 bytes) as words, sentences or graphemes, per the Unicode UAX #29 spec.
@@ -19,7 +21,7 @@ public ref struct StreamTokenizer<T> where T : struct
 	/// Default is 1024 bytes. The tokenizer is intended for natural language, so we don't expect you'll find text with a token beyond a couple of dozen bytes.
 	/// If this cutoff is too small for your data, increase it. If you'd like to save memory, reduce it.
 	/// </param>
-	internal StreamTokenizer(Buffer<T> buffer, Tokenizer<T> tok)
+	internal StreamTokenizer(Buffer<TSpan> buffer, Tokenizer<TSpan, TSplit> tok)
 	{
 		this.tok = tok;
 		this.buffer = buffer;
@@ -33,9 +35,9 @@ public ref struct StreamTokenizer<T> where T : struct
 		return tok.MoveNext();
 	}
 
-	public readonly ReadOnlySpan<T> Current => tok.Current;
+	public readonly ReadOnlySpan<TSpan> Current => tok.Current;
 
-	public readonly StreamTokenizer<T> GetEnumerator()
+	public readonly StreamTokenizer<TSpan, TSplit> GetEnumerator()
 	{
 		return this;
 	}
@@ -43,13 +45,15 @@ public ref struct StreamTokenizer<T> where T : struct
 
 public static class StreamExtensions
 {
-	public static void SetStream(ref this StreamTokenizer<byte> stok, Stream stream)
+	public static void SetStream<TSplit>(ref this StreamTokenizer<byte, TSplit> stok, Stream stream)
+		where TSplit : struct, ISplit<byte>
 	{
 		stok.tok.SetText([]);
 		stok.buffer.SetRead(stream.Read);
 	}
 
-	public static void SetStream(ref this StreamTokenizer<char> stok, TextReader stream)
+	public static void SetStream<TSplit>(ref this StreamTokenizer<char, TSplit> stok, TextReader stream)
+		where TSplit : struct, ISplit<char>
 	{
 		stok.tok.SetText([]);
 		stok.buffer.SetRead(stream.Read);

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -1,7 +1,5 @@
 namespace uax29;
 
-using System.ComponentModel;
-
 public enum TokenType
 {
 	Words, Graphemes, Sentences

--- a/uax29/Tokenizer.cs
+++ b/uax29/Tokenizer.cs
@@ -21,7 +21,7 @@ public static class Tokenizer
 	/// </returns>
 	public static Tokenizer<char> Create(string input, TokenType tokenType = TokenType.Words)
 	{
-		var split = charSplits[tokenType];
+		var split = charSplits[(int)tokenType];
 		return new Tokenizer<char>(input.AsSpan(), split);
 	}
 
@@ -35,7 +35,7 @@ public static class Tokenizer
 	/// </returns>
 	public static Tokenizer<byte> Create(ReadOnlySpan<byte> input, TokenType tokenType = TokenType.Words)
 	{
-		var split = byteSplits[tokenType];
+		var split = byteSplits[(int)tokenType];
 		return new Tokenizer<byte>(input, split);
 	}
 
@@ -49,7 +49,7 @@ public static class Tokenizer
 	/// </returns>
 	public static Tokenizer<char> Create(ReadOnlySpan<char> input, TokenType tokenType = TokenType.Words)
 	{
-		var split = charSplits[tokenType];
+		var split = charSplits[(int)tokenType];
 		return new Tokenizer<char>(input, split);
 	}
 
@@ -94,19 +94,9 @@ public static class Tokenizer
 		return new StreamTokenizer<char>(buffer, tok);
 	}
 
-	static readonly Dictionary<TokenType, Split<byte>> byteSplits = new()
-	{
-		{TokenType.Words, Words.SplitUtf8Bytes},
-		{TokenType.Graphemes, Graphemes.SplitUtf8Bytes},
-		{TokenType.Sentences, Sentences.SplitUtf8Bytes},
-	};
+	static readonly Split<byte>[] byteSplits = [Words.SplitUtf8Bytes, Graphemes.SplitUtf8Bytes, Sentences.SplitUtf8Bytes];
+	static readonly Split<char>[] charSplits = [Words.SplitChars, Graphemes.SplitChars, Sentences.SplitChars];
 
-	static readonly Dictionary<TokenType, Split<char>> charSplits = new()
-	{
-		{TokenType.Words, Words.SplitChars},
-		{TokenType.Graphemes, Graphemes.SplitChars},
-		{TokenType.Sentences, Sentences.SplitChars},
-	};
 }
 
 /// <summary>

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -10,7 +10,7 @@ internal static partial class Words
 {
 	private readonly struct WordsIgnore : IIgnore
 	{
-		static Property IIgnore.Ignore { get; } = Extend | Format | ZWJ;
+		public static Property Ignore { get; } = Extend | Format | ZWJ;
 	}
 
 	private readonly struct WordsDict : IDict
@@ -18,15 +18,10 @@ internal static partial class Words
 		static Dict IDict.Dict { get; } = Words.Dict;
 	}
 
-	internal static readonly Split<byte> SplitUtf8Bytes = Splitter<byte, Utf8Decoder, WordsDict, WordsIgnore>.Split;
-	internal static readonly Split<char> SplitChars = Splitter<char, Utf16Decoder, WordsDict, WordsIgnore>.Split;
-
-	internal sealed class Splitter<TSpan, TDecoder, TDict, TIgnore>
+	internal sealed class Splitter<TSpan, TDecoder>
 		where TDecoder : struct, IDecoder<TSpan> // force non-reference so gets de-virtualized
-		where TDict : struct, IDict // force non-reference so gets de-virtualized
-		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
-		private static SplitterBase.Context<TSpan, TDecoder, TDict, TIgnore> ctx { get; } = default;
+		private static SplitterBase.Context<TSpan, TDecoder, WordsDict, WordsIgnore> ctx { get; } = default;
 
 		internal Splitter() : base()
 		{ }
@@ -139,7 +134,7 @@ internal static partial class Words
 				// The previous/subsequent methods are shorthand for "seek a property but skip over Extend|Format|ZWJ on the way"
 
 				// https://unicode.org/reports/tr29/#WB5
-				if (current.Is(AHLetter) && last.Is(AHLetter | TIgnore.Ignore))
+				if (current.Is(AHLetter) && last.Is(AHLetter | WordsIgnore.Ignore))
 				{
 					// Optimization: maybe a run without ignored characters
 					if (last.Is(AHLetter))
@@ -182,7 +177,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB6 can possibly apply
-				var maybeWB6 = current.Is(MidLetter | MidNumLetQ) && last.Is(AHLetter | TIgnore.Ignore);
+				var maybeWB6 = current.Is(MidLetter | MidNumLetQ) && last.Is(AHLetter | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB6
 				if (maybeWB6)
@@ -195,7 +190,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB7 can possibly apply
-				var maybeWB7 = current.Is(AHLetter) && last.Is(MidLetter | MidNumLetQ | TIgnore.Ignore);
+				var maybeWB7 = current.Is(AHLetter) && last.Is(MidLetter | MidNumLetQ | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB7
 				if (maybeWB7)
@@ -209,7 +204,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB7a can possibly apply
-				var maybeWB7a = current.Is(Single_Quote) && last.Is(Hebrew_Letter | TIgnore.Ignore);
+				var maybeWB7a = current.Is(Single_Quote) && last.Is(Hebrew_Letter | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB7a
 				if (maybeWB7a)
@@ -222,7 +217,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB7b can possibly apply
-				var maybeWB7b = current.Is(Double_Quote) && last.Is(Hebrew_Letter | TIgnore.Ignore);
+				var maybeWB7b = current.Is(Double_Quote) && last.Is(Hebrew_Letter | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB7b
 				if (maybeWB7b)
@@ -235,7 +230,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB7c can possibly apply
-				var maybeWB7c = current.Is(Hebrew_Letter) && last.Is(Double_Quote | TIgnore.Ignore);
+				var maybeWB7c = current.Is(Hebrew_Letter) && last.Is(Double_Quote | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB7c
 				if (maybeWB7c)
@@ -251,7 +246,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB8
 				// https://unicode.org/reports/tr29/#WB9
 				// https://unicode.org/reports/tr29/#WB10
-				if (current.Is(Numeric | AHLetter) && last.Is(Numeric | AHLetter | TIgnore.Ignore))
+				if (current.Is(Numeric | AHLetter) && last.Is(Numeric | AHLetter | WordsIgnore.Ignore))
 				{
 					// Note: this logic de facto expresses WB5 as well, but harmless since WB5
 					// was already tested above
@@ -302,7 +297,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB11 can possibly apply
-				var maybeWB11 = current.Is(Numeric) && last.Is(MidNum | MidNumLetQ | TIgnore.Ignore);
+				var maybeWB11 = current.Is(Numeric) && last.Is(MidNum | MidNumLetQ | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB11
 				if (maybeWB11)
@@ -316,7 +311,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB12 can possibly apply
-				var maybeWB12 = current.Is(MidNum | MidNumLetQ) && last.Is(Numeric | TIgnore.Ignore);
+				var maybeWB12 = current.Is(MidNum | MidNumLetQ) && last.Is(Numeric | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB12
 				if (maybeWB12)
@@ -329,7 +324,7 @@ internal static partial class Words
 				}
 
 				// https://unicode.org/reports/tr29/#WB13
-				if (current.Is(Katakana) && last.Is(Katakana | TIgnore.Ignore))
+				if (current.Is(Katakana) && last.Is(Katakana | WordsIgnore.Ignore))
 				{
 					// Optimization: maybe a run without ignored characters
 					if (last.Is(Katakana))
@@ -372,7 +367,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB13a can possibly apply
-				var maybeWB13a = current.Is(ExtendNumLet) && last.Is(AHLetter | Numeric | Katakana | ExtendNumLet | TIgnore.Ignore);
+				var maybeWB13a = current.Is(ExtendNumLet) && last.Is(AHLetter | Numeric | Katakana | ExtendNumLet | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB13a
 				if (maybeWB13a)
@@ -385,7 +380,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB13b can possibly apply
-				var maybeWB13b = current.Is(AHLetter | Numeric | Katakana) && last.Is(ExtendNumLet | TIgnore.Ignore);
+				var maybeWB13b = current.Is(AHLetter | Numeric | Katakana) && last.Is(ExtendNumLet | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB13b
 				if (maybeWB13b)
@@ -398,7 +393,7 @@ internal static partial class Words
 				}
 
 				// Optimization: determine if WB15 or WB16 can possibly apply
-				var maybeWB1516 = current.Is(Regional_Indicator) && last.Is(Regional_Indicator | TIgnore.Ignore);
+				var maybeWB1516 = current.Is(Regional_Indicator) && last.Is(Regional_Indicator | WordsIgnore.Ignore);
 
 				// https://unicode.org/reports/tr29/#WB15 and
 				// https://unicode.org/reports/tr29/#WB16
@@ -432,7 +427,7 @@ internal static partial class Words
 							break;
 						}
 
-						if (lookup.Is(TIgnore.Ignore))
+						if (lookup.Is(WordsIgnore.Ignore))
 						{
 							continue;
 						}

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -1,4 +1,4 @@
-﻿namespace uax29;
+namespace uax29;
 
 using System.Buffers;
 using System.Text;
@@ -6,450 +6,458 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
+/// Make SplitterBase helpers available
+using static SplitterBase;
+
 internal static partial class Words
 {
-    internal static readonly Split<byte> SplitUtf8Bytes = new Splitter<byte>(Rune.DecodeFromUtf8, Rune.DecodeLastFromUtf8).Split;
-    internal static readonly Split<char> SplitChars = new Splitter<char>(Rune.DecodeFromUtf16, Rune.DecodeLastFromUtf16).Split;
-
-    internal class Splitter<TSpan> : SplitterBase<TSpan>
-    {
-        internal Splitter(Decoder<TSpan> decodeFirstRune, Decoder<TSpan> decodeLastRune) :
-            base(Words.Dict, Ignore, decodeFirstRune, decodeLastRune)
-        { }
-
-        const Property AHLetter = ALetter | Hebrew_Letter;
-        const Property MidNumLetQ = MidNumLet | Single_Quote;
-        new const Property Ignore = Extend | Format | ZWJ;
-
-        public override int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
-        {
-            if (input.Length == 0)
-            {
-                return 0;
-            }
-
-            // These vars are stateful across loop iterations
-            int pos = 0;
-            int w;
-            Property current = 0;
-
-            while (true)
-            {
-                var sot = pos == 0;             // "start of text"
-                var eot = pos == input.Length;   // "end of text"
-
-                if (eot)
-                {
-                    if (!atEOF)
-                    {
-                        // TODO Token extends past current data, request more
-                        return 0;
-                    }
-
-                    // https://unicode.org/reports/tr29/#WB2
-                    break;
-                }
-
-                var last = current;
-
-                var status = DecodeFirstRune(input[pos..], out Rune rune, out w);
-                if (status != OperationStatus.Done)
-                {
-                    // Garbage in, garbage out
-                    pos += w;
-                    break;
-                }
-                if (w == 0)
-                {
-                    if (atEOF)
-                    {
-                        // Just return the bytes, we can't do anything with them
-                        pos = input.Length;
-                        break;
-                    }
-                    // Rune extends past current data, request more
-                    return 0;
-                }
-
-                current = Dict.Lookup(rune.Value);
-
-                // https://unicode.org/reports/tr29/#WB1
-                if (sot)
-                {
-                    pos += w;
-                    continue;
-                }
-
-                // Optimization: no rule can possibly apply
-                if ((current | last) == 0)
-                { // i.e. both are zero
-                    break;
-                }
-
-                // https://unicode.org/reports/tr29/#WB3
-                if (current.Is(LF) && last.Is(CR))
-                {
-                    pos += w;
-                    continue;
-                }
-
-                // https://unicode.org/reports/tr29/#WB3a
-                // https://unicode.org/reports/tr29/#WB3b
-                if ((last | current).Is(Newline | CR | LF))
-                {
-                    break;
-                }
-
-                // https://unicode.org/reports/tr29/#WB3c
-                if (current.Is(Extended_Pictographic) && last.Is(ZWJ))
-                {
-                    pos += w;
-                    continue;
-                }
-
-                // https://unicode.org/reports/tr29/#WB3d
-                if ((current & last).Is(WSegSpace))
-                {
-                    pos += w;
-                    continue;
-                }
-
-                // https://unicode.org/reports/tr29/#WB4
-                if (current.Is(Extend | Format | ZWJ))
-                {
-                    pos += w;
-                    continue;
-                }
-
-                // WB4 applies to subsequent rules; there is an implied "ignoring Extend & Format & ZWJ"
-                // https://unicode.org/reports/tr29/#Grapheme_Cluster_and_Format_Rules
-                // The previous/subsequent methods are shorthand for "seek a property but skip over Extend|Format|ZWJ on the way"
-
-                // https://unicode.org/reports/tr29/#WB5
-                if (current.Is(AHLetter) && last.Is(AHLetter | Ignore))
-                {
-                    // Optimization: maybe a run without ignored characters
-                    if (last.Is(AHLetter))
-                    {
-                        pos += w;
-                        while (pos < input.Length)
-                        {
-                            status = DecodeFirstRune(input[pos..], out Rune rune2, out int w2);
-                            if (status != OperationStatus.Done)
-                            {
-                                // Garbage in, garbage out
-                                break;
-                            }
-                            if (w2 == 0)
-                            {
-                                break;
-                            }
-
-                            var lookup = Dict.Lookup(rune2.Value);
-                            if (!lookup.Is(AHLetter))
-                            {
-                                break;
-                            }
-
-                            // Update stateful vars
-                            current = lookup;
-                            w = w2;
-
-                            pos += w;
-                        }
-                        continue;
-                    }
-
-                    // Otherwise, do proper look back per WB4
-                    if (Previous(AHLetter, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB6 can possibly apply
-                var maybeWB6 = current.Is(MidLetter | MidNumLetQ) && last.Is(AHLetter | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB6
-                if (maybeWB6)
-                {
-                    if (Subsequent(AHLetter, input[(pos + w)..]) && Previous(AHLetter, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB7 can possibly apply
-                var maybeWB7 = current.Is(AHLetter) && last.Is(MidLetter | MidNumLetQ | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB7
-                if (maybeWB7)
-                {
-                    var i = PreviousIndex(MidLetter | MidNumLetQ, input[..pos]);
-                    if (i > 0 && Previous(AHLetter, input[..i]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB7a can possibly apply
-                var maybeWB7a = current.Is(Single_Quote) && last.Is(Hebrew_Letter | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB7a
-                if (maybeWB7a)
-                {
-                    if (Previous(Hebrew_Letter, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB7b can possibly apply
-                var maybeWB7b = current.Is(Double_Quote) && last.Is(Hebrew_Letter | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB7b
-                if (maybeWB7b)
-                {
-                    if (Subsequent(Hebrew_Letter, input[(pos + w)..]) && Previous(Hebrew_Letter, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB7c can possibly apply
-                var maybeWB7c = current.Is(Hebrew_Letter) && last.Is(Double_Quote | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB7c
-                if (maybeWB7c)
-                {
-                    var i = PreviousIndex(Double_Quote, input[..pos]);
-                    if (i > 0 && Previous(Hebrew_Letter, input[..i]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // https://unicode.org/reports/tr29/#WB8
-                // https://unicode.org/reports/tr29/#WB9
-                // https://unicode.org/reports/tr29/#WB10
-                if (current.Is(Numeric | AHLetter) && last.Is(Numeric | AHLetter | Ignore))
-                {
-                    // Note: this logic de facto expresses WB5 as well, but harmless since WB5
-                    // was already tested above
-
-                    // Optimization: maybe a run without ignored characters
-                    if (last.Is(Numeric | AHLetter))
-                    {
-                        pos += w;
-                        while (pos < input.Length)
-                        {
-                            status = DecodeFirstRune(input[pos..], out Rune rune2, out int w2);
-                            if (status != OperationStatus.Done)
-                            {
-                                // Garbage in, garbage out
-                                break;
-                            }
-                            if (w2 == 0)
-                            {
-                                break;
-                            }
-
-                            var lookup = Dict.Lookup(rune2.Value);
-
-                            if (!lookup.Is(Numeric | AHLetter))
-                            {
-                                break;
-                            }
-                            if (w2 == 0)
-                            {
-                                break;
-                            }
-
-                            // Update stateful vars
-                            current = lookup;
-                            w = w2;
-
-                            pos += w;
-                        }
-                        continue;
-                    }
-
-                    // Otherwise, do proper lookback per WB4
-                    if (Previous(Numeric | AHLetter, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB11 can possibly apply
-                var maybeWB11 = current.Is(Numeric) && last.Is(MidNum | MidNumLetQ | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB11
-                if (maybeWB11)
-                {
-                    var i = PreviousIndex(MidNum | MidNumLetQ, input[..pos]);
-                    if (i > 0 && Previous(Numeric, input[..i]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB12 can possibly apply
-                var maybeWB12 = current.Is(MidNum | MidNumLetQ) && last.Is(Numeric | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB12
-                if (maybeWB12)
-                {
-                    if (Subsequent(Numeric, input[(pos + w)..]) && Previous(Numeric, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // https://unicode.org/reports/tr29/#WB13
-                if (current.Is(Katakana) && last.Is(Katakana | Ignore))
-                {
-                    // Optimization: maybe a run without ignored characters
-                    if (last.Is(Katakana))
-                    {
-                        pos += w;
-                        while (pos < input.Length)
-                        {
-                            status = DecodeFirstRune(input[pos..], out Rune rune2, out int w2);
-                            if (status != OperationStatus.Done)
-                            {
-                                // Garbage in, garbage out
-                                break;
-                            }
-                            if (w2 == 0)
-                            {
-                                break;
-                            }
-
-                            var lookup = Dict.Lookup(rune2.Value);
-                            if (!lookup.Is(Katakana))
-                            {
-                                break;
-                            }
-
-                            // Update stateful vars
-                            current = lookup;
-                            w = w2;
-
-                            pos += w;
-                        }
-                        continue;
-                    }
-
-                    // Otherwise, do proper lookback per WB4
-                    if (Previous(Katakana, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB13a can possibly apply
-                var maybeWB13a = current.Is(ExtendNumLet) && last.Is(AHLetter | Numeric | Katakana | ExtendNumLet | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB13a
-                if (maybeWB13a)
-                {
-                    if (Previous(AHLetter | Numeric | Katakana | ExtendNumLet, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB13b can possibly apply
-                var maybeWB13b = current.Is(AHLetter | Numeric | Katakana) && last.Is(ExtendNumLet | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB13b
-                if (maybeWB13b)
-                {
-                    if (Previous(ExtendNumLet, input[..pos]))
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // Optimization: determine if WB15 or WB16 can possibly apply
-                var maybeWB1516 = current.Is(Regional_Indicator) && last.Is(Regional_Indicator | Ignore);
-
-                // https://unicode.org/reports/tr29/#WB15 and
-                // https://unicode.org/reports/tr29/#WB16
-                if (maybeWB1516)
-                {
-                    // WB15: Odd number of RI before hitting start of text
-                    // WB16: Odd number of RI before hitting [^RI], aka "not RI"
-
-                    var i = pos;
-                    var count = 0;
-
-                    while (i > 0)
-                    {
-                        status = DecodeLastRune(input[..i], out Rune rune2, out int w2);
-                        if (status != OperationStatus.Done)
-                        {
-                            // Garbage in, garbage out
-                            break;
-                        }
-                        if (w2 == 0)
-                        {
-                            break;
-                        }
-
-                        i -= w2;
-
-                        var lookup = Dict.Lookup(rune2.Value);
-                        if (status != OperationStatus.Done)
-                        {
-                            // Garbage in, garbage out
-                            break;
-                        }
-
-                        if (lookup.Is(Ignore))
-                        {
-                            continue;
-                        }
-
-                        if (!lookup.Is(Regional_Indicator))
-                        {
-                            // It's WB16
-                            break;
-                        }
-
-                        count++;
-                    }
-
-                    // If i == 0, we fell through and hit sot (start of text), so WB15 applies
-                    // If i > 0, we hit a non-RI, so WB16 applies
-
-                    var odd = count % 2 == 1;
-                    if (odd)
-                    {
-                        pos += w;
-                        continue;
-                    }
-                }
-
-                // https://unicode.org/reports/tr29/#WB999
-                // If we fall through all the above rules, it's a word break
-                break;
-            }
-
-            return pos;
-        }
-    }
+	private readonly struct WordsIgnore : IDictAndIgnore
+	{
+		static Dict IDictAndIgnore.Dict { get; } = Words.Dict;
+		static Property IDictAndIgnore.Ignore { get; } = Extend | Format | ZWJ;
+	}
+
+	internal static readonly Split<byte> SplitUtf8Bytes = Splitter<byte, Utf8Decoder<WordsIgnore>>.Split;
+	internal static readonly Split<char> SplitChars = Splitter<char, Utf16Decoder<WordsIgnore>>.Split;
+
+	internal sealed class Splitter<TSpan, TDecoder>
+		where TDecoder : struct, IDecoder<TSpan>
+	{
+		internal Splitter() : base()
+		{ }
+
+		const Property AHLetter = ALetter | Hebrew_Letter;
+		const Property MidNumLetQ = MidNumLet | Single_Quote;
+		
+		public static int Split(ReadOnlySpan<TSpan> input, bool atEOF = true)
+		{
+			if (input.Length == 0)
+			{
+				return 0;
+			}
+
+			// These vars are stateful across loop iterations
+			int pos = 0;
+			int w;
+			Property current = 0;
+
+			while (true)
+			{
+				var sot = pos == 0;             // "start of text"
+				var eot = pos == input.Length;   // "end of text"
+
+				if (eot)
+				{
+					if (!atEOF)
+					{
+						// TODO Token extends past current data, request more
+						return 0;
+					}
+
+					// https://unicode.org/reports/tr29/#WB2
+					break;
+				}
+
+				var last = current;
+
+				var status = TDecoder.DecodeFirstRune(input[pos..], out Rune rune, out w);
+				if (status != OperationStatus.Done)
+				{
+					// Garbage in, garbage out
+					pos += w;
+					break;
+				}
+				if (w == 0)
+				{
+					if (atEOF)
+					{
+						// Just return the bytes, we can't do anything with them
+						pos = input.Length;
+						break;
+					}
+					// Rune extends past current data, request more
+					return 0;
+				}
+
+				current = Dict.Lookup(rune.Value);
+
+				// https://unicode.org/reports/tr29/#WB1
+				if (sot)
+				{
+					pos += w;
+					continue;
+				}
+
+				// Optimization: no rule can possibly apply
+				if ((current | last) == 0)
+				{ // i.e. both are zero
+					break;
+				}
+
+				// https://unicode.org/reports/tr29/#WB3
+				if (current.Is(LF) && last.Is(CR))
+				{
+					pos += w;
+					continue;
+				}
+
+				// https://unicode.org/reports/tr29/#WB3a
+				// https://unicode.org/reports/tr29/#WB3b
+				if ((last | current).Is(Newline | CR | LF))
+				{
+					break;
+				}
+
+				// https://unicode.org/reports/tr29/#WB3c
+				if (current.Is(Extended_Pictographic) && last.Is(ZWJ))
+				{
+					pos += w;
+					continue;
+				}
+
+				// https://unicode.org/reports/tr29/#WB3d
+				if ((current & last).Is(WSegSpace))
+				{
+					pos += w;
+					continue;
+				}
+
+				// https://unicode.org/reports/tr29/#WB4
+				if (current.Is(Extend | Format | ZWJ))
+				{
+					pos += w;
+					continue;
+				}
+
+				// WB4 applies to subsequent rules; there is an implied "ignoring Extend & Format & ZWJ"
+				// https://unicode.org/reports/tr29/#Grapheme_Cluster_and_Format_Rules
+				// The previous/subsequent methods are shorthand for "seek a property but skip over Extend|Format|ZWJ on the way"
+
+				// https://unicode.org/reports/tr29/#WB5
+				if (current.Is(AHLetter) && last.Is(AHLetter | TDecoder.Ignore))
+				{
+					// Optimization: maybe a run without ignored characters
+					if (last.Is(AHLetter))
+					{
+						pos += w;
+						while (pos < input.Length)
+						{
+							status = TDecoder.DecodeFirstRune(input[pos..], out Rune rune2, out int w2);
+							if (status != OperationStatus.Done)
+							{
+								// Garbage in, garbage out
+								break;
+							}
+							if (w2 == 0)
+							{
+								break;
+							}
+
+							var lookup = Dict.Lookup(rune2.Value);
+							if (!lookup.Is(AHLetter))
+							{
+								break;
+							}
+
+							// Update stateful vars
+							current = lookup;
+							w = w2;
+
+							pos += w;
+						}
+						continue;
+					}
+
+					// Otherwise, do proper look back per WB4
+					if (Previous<TSpan, TDecoder>(AHLetter, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB6 can possibly apply
+				var maybeWB6 = current.Is(MidLetter | MidNumLetQ) && last.Is(AHLetter | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB6
+				if (maybeWB6)
+				{
+					if (Subsequent<TSpan, TDecoder>(AHLetter, input[(pos + w)..]) && Previous<TSpan, TDecoder>(AHLetter, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB7 can possibly apply
+				var maybeWB7 = current.Is(AHLetter) && last.Is(MidLetter | MidNumLetQ | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB7
+				if (maybeWB7)
+				{
+					var i = PreviousIndex<TSpan, TDecoder>(MidLetter | MidNumLetQ, input[..pos]);
+					if (i > 0 && Previous<TSpan, TDecoder>(AHLetter, input[..i]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB7a can possibly apply
+				var maybeWB7a = current.Is(Single_Quote) && last.Is(Hebrew_Letter | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB7a
+				if (maybeWB7a)
+				{
+					if (Previous<TSpan, TDecoder>(Hebrew_Letter, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB7b can possibly apply
+				var maybeWB7b = current.Is(Double_Quote) && last.Is(Hebrew_Letter | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB7b
+				if (maybeWB7b)
+				{
+					if (Subsequent<TSpan, TDecoder>(Hebrew_Letter, input[(pos + w)..]) && Previous<TSpan, TDecoder>(Hebrew_Letter, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB7c can possibly apply
+				var maybeWB7c = current.Is(Hebrew_Letter) && last.Is(Double_Quote | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB7c
+				if (maybeWB7c)
+				{
+					var i = PreviousIndex<TSpan, TDecoder>(Double_Quote, input[..pos]);
+					if (i > 0 && Previous<TSpan, TDecoder>(Hebrew_Letter, input[..i]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// https://unicode.org/reports/tr29/#WB8
+				// https://unicode.org/reports/tr29/#WB9
+				// https://unicode.org/reports/tr29/#WB10
+				if (current.Is(Numeric | AHLetter) && last.Is(Numeric | AHLetter | TDecoder.Ignore))
+				{
+					// Note: this logic de facto expresses WB5 as well, but harmless since WB5
+					// was already tested above
+
+					// Optimization: maybe a run without ignored characters
+					if (last.Is(Numeric | AHLetter))
+					{
+						pos += w;
+						while (pos < input.Length)
+						{
+							status = TDecoder.DecodeFirstRune(input[pos..], out Rune rune2, out int w2);
+							if (status != OperationStatus.Done)
+							{
+								// Garbage in, garbage out
+								break;
+							}
+							if (w2 == 0)
+							{
+								break;
+							}
+
+							var lookup = Dict.Lookup(rune2.Value);
+
+							if (!lookup.Is(Numeric | AHLetter))
+							{
+								break;
+							}
+							if (w2 == 0)
+							{
+								break;
+							}
+
+							// Update stateful vars
+							current = lookup;
+							w = w2;
+
+							pos += w;
+						}
+						continue;
+					}
+
+					// Otherwise, do proper lookback per WB4
+					if (Previous<TSpan, TDecoder>(Numeric | AHLetter, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB11 can possibly apply
+				var maybeWB11 = current.Is(Numeric) && last.Is(MidNum | MidNumLetQ | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB11
+				if (maybeWB11)
+				{
+					var i = PreviousIndex<TSpan, TDecoder>(MidNum | MidNumLetQ, input[..pos]);
+					if (i > 0 && Previous<TSpan, TDecoder>(Numeric, input[..i]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB12 can possibly apply
+				var maybeWB12 = current.Is(MidNum | MidNumLetQ) && last.Is(Numeric | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB12
+				if (maybeWB12)
+				{
+					if (Subsequent<TSpan, TDecoder>(Numeric, input[(pos + w)..]) && Previous<TSpan, TDecoder>(Numeric, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// https://unicode.org/reports/tr29/#WB13
+				if (current.Is(Katakana) && last.Is(Katakana | TDecoder.Ignore))
+				{
+					// Optimization: maybe a run without ignored characters
+					if (last.Is(Katakana))
+					{
+						pos += w;
+						while (pos < input.Length)
+						{
+							status = TDecoder.DecodeFirstRune(input[pos..], out Rune rune2, out int w2);
+							if (status != OperationStatus.Done)
+							{
+								// Garbage in, garbage out
+								break;
+							}
+							if (w2 == 0)
+							{
+								break;
+							}
+
+							var lookup = Dict.Lookup(rune2.Value);
+							if (!lookup.Is(Katakana))
+							{
+								break;
+							}
+
+							// Update stateful vars
+							current = lookup;
+							w = w2;
+
+							pos += w;
+						}
+						continue;
+					}
+
+					// Otherwise, do proper lookback per WB4
+					if (Previous<TSpan, TDecoder>(Katakana, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB13a can possibly apply
+				var maybeWB13a = current.Is(ExtendNumLet) && last.Is(AHLetter | Numeric | Katakana | ExtendNumLet | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB13a
+				if (maybeWB13a)
+				{
+					if (Previous<TSpan, TDecoder>(AHLetter | Numeric | Katakana | ExtendNumLet, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB13b can possibly apply
+				var maybeWB13b = current.Is(AHLetter | Numeric | Katakana) && last.Is(ExtendNumLet | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB13b
+				if (maybeWB13b)
+				{
+					if (Previous<TSpan, TDecoder>(ExtendNumLet, input[..pos]))
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// Optimization: determine if WB15 or WB16 can possibly apply
+				var maybeWB1516 = current.Is(Regional_Indicator) && last.Is(Regional_Indicator | TDecoder.Ignore);
+
+				// https://unicode.org/reports/tr29/#WB15 and
+				// https://unicode.org/reports/tr29/#WB16
+				if (maybeWB1516)
+				{
+					// WB15: Odd number of RI before hitting start of text
+					// WB16: Odd number of RI before hitting [^RI], aka "not RI"
+
+					var i = pos;
+					var count = 0;
+
+					while (i > 0)
+					{
+						status = TDecoder.DecodeLastRune(input[..i], out Rune rune2, out int w2);
+						if (status != OperationStatus.Done)
+						{
+							// Garbage in, garbage out
+							break;
+						}
+						if (w2 == 0)
+						{
+							break;
+						}
+
+						i -= w2;
+
+						var lookup = Dict.Lookup(rune2.Value);
+						if (status != OperationStatus.Done)
+						{
+							// Garbage in, garbage out
+							break;
+						}
+
+						if (lookup.Is(TDecoder.Ignore))
+						{
+							continue;
+						}
+
+						if (!lookup.Is(Regional_Indicator))
+						{
+							// It's WB16
+							break;
+						}
+
+						count++;
+					}
+
+					// If i == 0, we fell through and hit sot (start of text), so WB15 applies
+					// If i > 0, we hit a non-RI, so WB16 applies
+
+					var odd = count % 2 == 1;
+					if (odd)
+					{
+						pos += w;
+						continue;
+					}
+				}
+
+				// https://unicode.org/reports/tr29/#WB999
+				// If we fall through all the above rules, it's a word break
+				break;
+			}
+
+			return pos;
+		}
+	}
 }

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -6,9 +6,6 @@ using System.Text;
 /// A bitmap of Unicode categories
 using Property = uint;
 
-/// Make SplitterBase helpers available
-using static SplitterBase;
-
 internal static partial class Words
 {
 	private readonly struct WordsIgnore : IIgnore
@@ -29,6 +26,8 @@ internal static partial class Words
 		where TDict : struct, IDict // force non-reference so gets de-virtualized
 		where TIgnore : struct, IIgnore // force non-reference so gets de-virtualized
 	{
+		private static SplitterBase.Context<TSpan, TDecoder, TDict, TIgnore> ctx { get; } = default;
+
 		internal Splitter() : base()
 		{ }
 
@@ -175,7 +174,7 @@ internal static partial class Words
 					}
 
 					// Otherwise, do proper look back per WB4
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(AHLetter, input[..pos]))
+					if (ctx.Previous(AHLetter, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -188,7 +187,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB6
 				if (maybeWB6)
 				{
-					if (Subsequent<TSpan, TDecoder, TDict, TIgnore>(AHLetter, input[(pos + w)..]) && Previous<TSpan, TDecoder, TDict, TIgnore>(AHLetter, input[..pos]))
+					if (ctx.Subsequent(AHLetter, input[(pos + w)..]) && ctx.Previous(AHLetter, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -201,8 +200,8 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB7
 				if (maybeWB7)
 				{
-					var i = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(MidLetter | MidNumLetQ, input[..pos]);
-					if (i > 0 && Previous<TSpan, TDecoder, TDict, TIgnore>(AHLetter, input[..i]))
+					var i = ctx.PreviousIndex(MidLetter | MidNumLetQ, input[..pos]);
+					if (i > 0 && ctx.Previous(AHLetter, input[..i]))
 					{
 						pos += w;
 						continue;
@@ -215,7 +214,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB7a
 				if (maybeWB7a)
 				{
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(Hebrew_Letter, input[..pos]))
+					if (ctx.Previous(Hebrew_Letter, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -228,7 +227,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB7b
 				if (maybeWB7b)
 				{
-					if (Subsequent<TSpan, TDecoder, TDict, TIgnore>(Hebrew_Letter, input[(pos + w)..]) && Previous<TSpan, TDecoder, TDict, TIgnore>(Hebrew_Letter, input[..pos]))
+					if (ctx.Subsequent(Hebrew_Letter, input[(pos + w)..]) && ctx.Previous(Hebrew_Letter, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -241,8 +240,8 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB7c
 				if (maybeWB7c)
 				{
-					var i = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(Double_Quote, input[..pos]);
-					if (i > 0 && Previous<TSpan, TDecoder, TDict, TIgnore>(Hebrew_Letter, input[..i]))
+					var i = ctx.PreviousIndex(Double_Quote, input[..pos]);
+					if (i > 0 && ctx.Previous(Hebrew_Letter, input[..i]))
 					{
 						pos += w;
 						continue;
@@ -295,7 +294,7 @@ internal static partial class Words
 					}
 
 					// Otherwise, do proper lookback per WB4
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(Numeric | AHLetter, input[..pos]))
+					if (ctx.Previous(Numeric | AHLetter, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -308,8 +307,8 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB11
 				if (maybeWB11)
 				{
-					var i = PreviousIndex<TSpan, TDecoder, TDict, TIgnore>(MidNum | MidNumLetQ, input[..pos]);
-					if (i > 0 && Previous<TSpan, TDecoder, TDict, TIgnore>(Numeric, input[..i]))
+					var i = ctx.PreviousIndex(MidNum | MidNumLetQ, input[..pos]);
+					if (i > 0 && ctx.Previous(Numeric, input[..i]))
 					{
 						pos += w;
 						continue;
@@ -322,7 +321,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB12
 				if (maybeWB12)
 				{
-					if (Subsequent<TSpan, TDecoder, TDict, TIgnore>(Numeric, input[(pos + w)..]) && Previous<TSpan, TDecoder, TDict, TIgnore>(Numeric, input[..pos]))
+					if (ctx.Subsequent(Numeric, input[(pos + w)..]) && ctx.Previous(Numeric, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -365,7 +364,7 @@ internal static partial class Words
 					}
 
 					// Otherwise, do proper lookback per WB4
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(Katakana, input[..pos]))
+					if (ctx.Previous(Katakana, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -378,7 +377,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB13a
 				if (maybeWB13a)
 				{
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(AHLetter | Numeric | Katakana | ExtendNumLet, input[..pos]))
+					if (ctx.Previous(AHLetter | Numeric | Katakana | ExtendNumLet, input[..pos]))
 					{
 						pos += w;
 						continue;
@@ -391,7 +390,7 @@ internal static partial class Words
 				// https://unicode.org/reports/tr29/#WB13b
 				if (maybeWB13b)
 				{
-					if (Previous<TSpan, TDecoder, TDict, TIgnore>(ExtendNumLet, input[..pos]))
+					if (ctx.Previous(ExtendNumLet, input[..pos]))
 					{
 						pos += w;
 						continue;


### PR DESCRIPTION
Remove some delegates, remove inheritance, remove non-static classes.

Overall structure of the code remains the same, but this should be exploitable by the JIT to remove indirections in the hot path.

On my (AMD, Ryzen 4) box compare:

Old
---

| Method              | Mean      | Error     | StdDev    | Allocated |
|-------------------- |----------:|----------:|----------:|----------:|
| TokenizeBytes       |  1.097 ms | 0.0017 ms | 0.0015 ms |       1 B |
| TokenizeString      |  1.176 ms | 0.0013 ms | 0.0011 ms |       1 B |
| TokenizeStream      |  2.331 ms | 0.0054 ms | 0.0042 ms |    1179 B |
| TokenizeSetStream   | 18.012 ms | 0.0465 ms | 0.0363 ms |    1775 B |
| StringInfoGraphemes |  1.505 ms | 0.0026 ms | 0.0020 ms |      49 B |
| TokenizerGraphemes  |  1.307 ms | 0.0179 ms | 0.0159 ms |       1 B |

New
---
| Method              | Mean        | Error    | StdDev   | Allocated |
|-------------------- |------------:|---------:|---------:|----------:|
| TokenizeBytes       |  1,045.7 us |  2.70 us |  2.53 us |       1 B |
| TokenizeString      |    870.7 us |  3.32 us |  2.94 us |       1 B |
| TokenizeStream      |  1,851.9 us | 13.34 us | 11.83 us |    1177 B |
| TokenizeSetStream   | 17,565.2 us | 53.12 us | 49.69 us |    1775 B |
| StringInfoGraphemes |  1,505.9 us |  4.09 us |  3.62 us |      49 B |
| TokenizerGraphemes  |  1,172.4 us |  2.89 us |  2.56 us |       1 B |

---

Change in assembly is as expected, producing smaller call sites and going straight to the relevant methods.

For example

Old
---
```asm
...

G_M000_IG09:                ;; offset=0x0095
       mov      eax, ebp
       mov      r10, gword ptr [rsi+0x10]
       mov      r8d, edx
       sub      r8d, eax
       mov      r9d, eax
       mov      ecx, r8d
       add      r9, rcx
       mov      edx, edx
       cmp      r9, rdx
       ja       G_M000_IG97
       mov      edx, eax
       add      rdx, bword ptr [rbx]
       mov      bword ptr [rsp+0x20], rdx
       mov      dword ptr [rsp+0x28], r8d
       lea      rdx, [rsp+0x20]
       lea      r8, [rsp+0x70]
       lea      r9, [rsp+0x78]
       mov      rcx, gword ptr [r10+0x08]
       call     [r10+0x18]uax29.Decoder`1[ubyte]:Invoke(System.ReadOnlySpan`1[ubyte],byref,byref):int:this
       test     eax, eax
       je       SHORT G_M000_IG11

...
```

New
---

```asm
...

G_M000_IG09:                ;; offset=0x0090
       mov      eax, edi
       mov      edx, ecx
       sub      edx, eax
       mov      r8d, eax
       mov      r10d, edx
       add      r8, r10
       mov      ecx, ecx
       cmp      r8, rcx
       ja       G_M000_IG110
       mov      ecx, eax
       add      rcx, bword ptr [rbx]
       mov      bword ptr [rsp+0x20], rcx
       mov      dword ptr [rsp+0x28], edx
       lea      rcx, [rsp+0x20]
       lea      rdx, [rsp+0x70]
       lea      r8, [rsp+0x78]
       call     [System.Text.Rune:DecodeFromUtf8(System.ReadOnlySpan`1[ubyte],byref,byref):int]
       test     eax, eax
       je       SHORT G_M000_IG11

...
```

Could probably push this a little further by changing the returned type on various methods on `Tokenizer`.  Not sure how attractive that would be.