### PR TITLE
Try using Seek instead of Buffer

### DIFF
--- a/uax29/StreamTokenizer.Test.cs
+++ b/uax29/StreamTokenizer.Test.cs
@@ -51,6 +51,53 @@ public class TestStreamTokenizer
     /// Ensure that streamed text and static text return identical results.
     /// </summary>
     [Test]
+    public void Stream2()
+    {
+        var example = "abcdef ghijk"; // ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";
+        var examples = new List<string>()
+        {
+            example,											// smaller than the buffer
+			string.Concat(Enumerable.Repeat(example, 999))		// larger than the buffer
+		};
+
+        foreach (var input in examples)
+        {
+            var bytes = Encoding.UTF8.GetBytes(input);
+            var staticTokens = bytes.GetWords();
+
+            using var stream = new MemoryStream(bytes);
+            var streamTokens = stream.GetWords2();
+
+            foreach (var streamToken in streamTokens)
+            {
+                staticTokens.MoveNext();
+
+                var staticCurrent = Encoding.UTF8.GetString(staticTokens.Current);
+                var streamCurrent = Encoding.UTF8.GetString(streamToken);
+
+                Assert.That(streamCurrent, Is.EqualTo(staticCurrent));
+            }
+
+            staticTokens.Reset();
+            foreach (var streamToken in streamTokens)
+            {
+                staticTokens.MoveNext();
+
+                var staticCurrent = Encoding.UTF8.GetString(staticTokens.Current);
+                var streamCurrent = Encoding.UTF8.GetString(streamToken);
+
+                Assert.That(streamCurrent, Is.EqualTo(staticCurrent));
+            }
+
+            Assert.That(staticTokens.MoveNext(), Is.False, "Static tokens should have been consumed");
+            Assert.That(streamTokens.MoveNext(), Is.False, "Stream tokens should have been consumed");
+        }
+    }
+
+    /// <summary>
+    /// Ensure that streamed text and static text return identical results.
+    /// </summary>
+    [Test]
     public void StreamReader()
     {
         var example = "abcdefghijk lmnopq r stu vwxyz; ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";

--- a/uax29/StreamTokenizer2.cs
+++ b/uax29/StreamTokenizer2.cs
@@ -1,0 +1,105 @@
+﻿using Buffer;
+
+namespace uax29;
+
+using Buffer;
+
+/// <summary>
+/// StreamTokenizer is a small data structure for splitting strings from Streams or TextReaders. It implements GetEnumerator.
+/// </summary>
+public ref struct StreamTokenizer2
+{
+	readonly Split<byte> split;
+
+	internal Stream stream;
+	internal int consumed;
+	internal Span<byte> buf = new byte[1024];
+
+	internal int end;
+
+	bool begun = false;
+
+	/// <summary>
+	/// StreamTokenizer is a small data structure for splitting strings.
+	/// </summary>
+	/// <param name="buffer">For backing storage, typically created from a Stream or TextReader.</param>
+	/// <param name="split">A delegate that does the tokenizing. See Split<T> for details.</param>
+	internal StreamTokenizer2(Stream stream, Split<byte> split)
+	{
+		this.stream = stream;
+		this.split = split;
+	}
+
+	public bool MoveNext()
+	{
+		begun = true;
+
+		stream.Seek(consumed, SeekOrigin.Begin);
+
+		int read = stream.Read(buf);
+		// Interpret as EOF
+		if (read == 0)
+		{
+			return false;
+		}
+
+		var advance = this.split(buf[..read], read == 0);
+		// Interpret as EOF
+		if (advance == 0)
+		{
+			return false;
+		}
+
+		consumed += advance;
+		end = advance;
+
+		return true;
+	}
+
+	public ReadOnlySpan<byte> Current
+	{
+		get
+		{
+			return buf[..end];
+		}
+	}
+
+	public StreamTokenizer2 GetEnumerator()
+	{
+		return this;
+	}
+
+	/// <summary>
+	/// Iterates over all tokens and collects them into a List, allocating a new array for each token.
+	/// </summary>
+	/// <returns>List<byte[]> or List<char[]>, depending on the input.</returns>
+	public List<byte[]> ToList()
+	{
+		if (begun)
+		{
+			throw new InvalidOperationException("ToList must not be called after iteration has begun.");
+		}
+
+		var result = new List<byte[]>();
+		foreach (var token in this)
+		{
+			result.Add(token.ToArray());
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Iterates over all tokens and collects them into an Array, allocating a new array for each token.
+	/// </summary>
+	/// <returns>byte[][] or char[][], depending on the input.</returns>
+	public byte[][] ToArray()
+	{
+		if (begun)
+		{
+			throw new InvalidOperationException("ToArray must not be called after iteration has begun.");
+		}
+
+		return this.ToList().ToArray();
+	}
+}

--- a/uax29/Tokenizer.Words.cs
+++ b/uax29/Tokenizer.Words.cs
@@ -134,6 +134,11 @@ public static partial class Tokenizer
         return new StreamTokenizer<byte>(buffer, Words.SplitUtf8Bytes);
     }
 
+    public static StreamTokenizer2 GetWords2(this Stream stream, int minBufferBytes = 1024, byte[]? bufferStorage = null)
+    {
+        return new StreamTokenizer2(stream, Words.SplitUtf8Bytes);
+    }
+
     /// <summary>
     /// Split the words in the given <see cref="TextReader"/> / <see cref="StreamReader"/>.
     /// </summary>

--- a/uax29/Words.Splitter.cs
+++ b/uax29/Words.Splitter.cs
@@ -40,12 +40,6 @@ internal static partial class Words
 
                 if (eot)
                 {
-                    if (!atEOF)
-                    {
-                        // TODO Token extends past current data, request more
-                        return 0;
-                    }
-
                     // https://unicode.org/reports/tr29/#WB2
                     break;
                 }


### PR DESCRIPTION
The hypothesis is that if a stream is seekable, then my Buffer is redundant; use the Stream’s own buffer. Maybe avoid a byte[] allocation?

So far:

- It looks like the allocation will still be required, as the stream needs to Read into something, and stackalloc won’t fly since it’s needed by multiple methods.

So then, the prospect is just a bit less code and copying within the Buffer.

Not all streams guarantee Seek. So, we’d need to test CanSeek and use a Buffer anyway. More complexity than I prefer.

I think this won’t fly, but here for posterity.