### PR TITLE
Add support for .NET Framework 4.6.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Tests/Buffer.Test.cs
+++ b/Tests/Buffer.Test.cs
@@ -22,12 +22,12 @@ public class TestBuffer
 
 		while (buffer.Contents.Length > 0)
 		{
-			var contents = Encoding.UTF8.GetString(buffer.Contents);
+			var contents = Encoding.UTF8.GetString(buffer.Contents.ToArray());
 			Assert.That(input[consumed..], Does.StartWith(contents));
 
 			var remaining = buffer.Contents.Length;
 			var toConsume = remaining > consume ? remaining : consume;
-			result += Encoding.UTF8.GetString(buffer.Contents[0..toConsume]);
+			result += Encoding.UTF8.GetString(buffer.Contents[0..toConsume].ToArray());
 			buffer.Consume(toConsume);
 			consumed += toConsume;
 		}

--- a/Tests/Examples.Test.cs
+++ b/Tests/Examples.Test.cs
@@ -56,7 +56,7 @@ public class TestExample
         {
             // grapheme is a ReadOnlySpan<byte> of UTF-8 bytes
             // If you need it back as a string:
-            var s = Encoding.UTF8.GetString(grapheme);
+            var s = Encoding.UTF8.GetString(grapheme.ToArray());
             Console.WriteLine(s);
         }
 

--- a/Tests/Graphemes.Test.cs
+++ b/Tests/Graphemes.Test.cs
@@ -20,7 +20,7 @@ public class GraphemesTests
 	public void String(UnicodeTest test)
 	{
 		var s = Encoding.UTF8.GetString(test.input);
-		var tokens = Split.Graphemes(s);
+		var tokens = Split.Graphemes(s.AsSpan());
 		TestUnicode.TestChars(tokens, test);
 	}
 

--- a/Tests/RangeEnumerator.Test.cs
+++ b/Tests/RangeEnumerator.Test.cs
@@ -18,7 +18,7 @@ public class TestRangeEnumerator
 		var example = "Hello, how are you?";
 		var bytes = Encoding.UTF8.GetBytes(example);
 
-		var words = Split.Words(example);
+		var words = Split.Words(example.AsSpan());
 		var ranges = words.Ranges;
 
 		var first = new List<Range>();
@@ -49,14 +49,14 @@ public class TestRangeEnumerator
 
 		foreach (var option in options)
 		{
-			var tokens = Split.Words(example, option);
+			var tokens = Split.Words(example.AsSpan(), option);
 			var ranges = tokens.Ranges;
 
 			foreach (var range in ranges)
 			{
 				tokens.MoveNext();
 
-				var ranged = example.AsSpan(range);
+				var ranged = example.AsSpan(range.Start.Value, range.End.Value - range.Start.Value);
 				var token = tokens.Current;
 				Assert.That(token.SequenceEqual(ranged));
 			}
@@ -68,7 +68,7 @@ public class TestRangeEnumerator
 	{
 		var input = "Hello, how are you?";
 
-		var words = Split.Words(input);
+		var words = Split.Words(input.AsSpan());
 		var first = new List<string>();
 		foreach (var word in words)
 		{
@@ -77,7 +77,7 @@ public class TestRangeEnumerator
 
 		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
 
-		var ranges = Split.Words(input).Ranges;
+		var ranges = Split.Words(input.AsSpan()).Ranges;
 		var second = new List<string>();
 		foreach (var range in ranges)
 		{
@@ -90,7 +90,7 @@ public class TestRangeEnumerator
 	public void ToList()
 	{
 		var example = "abcdefghijk lmnopq r stu vwxyz; ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";
-		var words = Split.Words(example);
+		var words = Split.Words(example.AsSpan());
 		var ranges = words.Ranges;
 		var list = ranges.ToList();
 
@@ -120,7 +120,7 @@ public class TestRangeEnumerator
 	public void ToArray()
 	{
 		var example = "abcdefghijk lmnopq r stu vwxyz; ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";
-		var words = Split.Words(example);
+		var words = Split.Words(example.AsSpan());
 		var ranges = words.Ranges;
 		var array = ranges.ToArray();
 

--- a/Tests/Sentences.Test.cs
+++ b/Tests/Sentences.Test.cs
@@ -20,7 +20,7 @@ public class SentencesTests
 	public void String(UnicodeTest test)
 	{
 		var s = Encoding.UTF8.GetString(test.input);
-		var tokens = Split.Sentences(s);
+		var tokens = Split.Sentences(s.AsSpan());
 		TestUnicode.TestChars(tokens, test);
 	}
 

--- a/Tests/SplitEnumerator.Test.cs
+++ b/Tests/SplitEnumerator.Test.cs
@@ -18,7 +18,7 @@ public class TestEnumerator
 		var example = "Hello, how are you?";
 		var bytes = Encoding.UTF8.GetBytes(example);
 
-		var tokens = Split.Words(example);
+		var tokens = Split.Words(example.AsSpan());
 
 		var first = new List<string>();
 		foreach (var token in tokens)
@@ -44,7 +44,7 @@ public class TestEnumerator
 	{
 		var example = "Hello, how are you?";
 
-		var tokens = Split.Words(example);
+		var tokens = Split.Words(example.AsSpan());
 
 		var first = new List<string>();
 		foreach (var token in tokens)
@@ -54,7 +54,7 @@ public class TestEnumerator
 
 		Assert.That(first, Has.Count.GreaterThan(1));   // just make sure it did the thing
 
-		tokens.SetText(example);
+		tokens.SetText(example.AsSpan());
 
 		var second = new List<string>();
 		foreach (var token in tokens)
@@ -102,7 +102,7 @@ public class TestEnumerator
 
 		// Chars
 		{
-			Split.Words(input); got++;
+			Split.Words(input.AsSpan()); got++;
 
 			var array = input.ToCharArray();
 			Split.Words(array); got++;
@@ -116,7 +116,7 @@ public class TestEnumerator
 			Split.Words(reader); got++;
 		}
 		{
-			Split.Graphemes(input); got++;
+			Split.Graphemes(input.AsSpan()); got++;
 
 			var array = input.ToCharArray();
 			Split.Graphemes(array); got++;
@@ -130,7 +130,7 @@ public class TestEnumerator
 			Split.Graphemes(reader); got++;
 		}
 		{
-			Split.Sentences(input); got++;
+			Split.Sentences(input.AsSpan()); got++;
 
 			var array = input.ToCharArray();
 			Split.Sentences(array); got++;
@@ -188,7 +188,7 @@ public class TestEnumerator
 		var input = "Hello, how are you?";
 		var bytes = Encoding.UTF8.GetBytes(input);
 
-		var tokens = Split.Words(input);
+		var tokens = Split.Words(input.AsSpan());
 		var first = new List<string>();
 		while (tokens.MoveNext())
 		{
@@ -201,7 +201,7 @@ public class TestEnumerator
 		var second = new List<string>();
 		foreach (var token in tokens2)
 		{
-			var s = Encoding.UTF8.GetString(token);
+			var s = Encoding.UTF8.GetString(token.ToArray());
 			second.Add(s);
 		}
 		Assert.That(first.SequenceEqual(second));
@@ -211,7 +211,7 @@ public class TestEnumerator
 	public void ToList()
 	{
 		var example = "abcdefghijk lmnopq r stu vwxyz; ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";
-		var tokens = Split.Words(example);
+		var tokens = Split.Words(example.AsSpan());
 		var list = tokens.ToList();
 
 		var i = 0;
@@ -244,7 +244,7 @@ public class TestEnumerator
 	public void ToArray()
 	{
 		var example = "abcdefghijk lmnopq r stu vwxyz; ABC DEFG HIJKL MNOP Q RSTUV WXYZ! 你好，世界.";
-		var tokens = Split.Words(example);
+		var tokens = Split.Words(example.AsSpan());
 		var array = tokens.ToArray();
 
 		var i = 0;
@@ -279,7 +279,7 @@ public class TestEnumerator
 		var example = "Hello, how are you?";
 
 		{
-			var tokens = Split.Words(example);
+			var tokens = Split.Words(example.AsSpan());
 			tokens.MoveNext();
 			Assert.That(tokens.Position, Is.EqualTo(0));
 			tokens.MoveNext();
@@ -327,7 +327,7 @@ public class TestEnumerator
 			// Options.None should be lossless
 			var expected = example;
 			var got = string.Concat(
-				Split.Words(example, Options.None)
+				Split.Words(example.AsSpan(), Options.None)
 				.ToList()
 				.SelectMany(c => c)
 			);
@@ -339,7 +339,7 @@ public class TestEnumerator
 			// Options.OmitWhitespace should have no whitespace
 			var expected = new string(example.Where(c => !char.IsWhiteSpace(c)).ToArray());
 			var got = string.Concat(
-				Split.Words(example, Options.OmitWhitespace)
+				Split.Words(example.AsSpan(), Options.OmitWhitespace)
 				.ToList()
 				.SelectMany(c => c)
 			);

--- a/Tests/StreamEnumerator.Test.cs
+++ b/Tests/StreamEnumerator.Test.cs
@@ -40,8 +40,8 @@ public class TestStreamEnumerator
                 {
                     staticTokens.MoveNext();
 
-                    var expected = Encoding.UTF8.GetString(staticTokens.Current);
-                    var got = Encoding.UTF8.GetString(streamToken);
+                    var expected = Encoding.UTF8.GetString(staticTokens.Current.ToArray());
+                    var got = Encoding.UTF8.GetString(streamToken.ToArray());
 
                     Assert.That(got, Is.EqualTo(expected));
                 }
@@ -79,7 +79,7 @@ public class TestStreamEnumerator
                 foreach (var streamToken in streamTokens)
                 {
                     staticTokens.MoveNext();
-                    var staticCurrent = Encoding.UTF8.GetString(staticTokens.Current);
+                    var staticCurrent = Encoding.UTF8.GetString(staticTokens.Current.ToArray());
 
                     Assert.That(staticCurrent, Is.EqualTo(streamToken.ToString()));
                 }
@@ -102,7 +102,7 @@ public class TestStreamEnumerator
         var first = new List<string>();
         foreach (var token in tokens)
         {
-            var s = Encoding.UTF8.GetString(token);
+            var s = Encoding.UTF8.GetString(token.ToArray());
             first.Add(s);
         }
 
@@ -115,7 +115,7 @@ public class TestStreamEnumerator
         var second = new List<string>();
         foreach (var token in tokens)
         {
-            var s = Encoding.UTF8.GetString(token);
+            var s = Encoding.UTF8.GetString(token.ToArray());
             second.Add(s);
         }
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworks);net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/Unicode.Test.cs
+++ b/Tests/Unicode.Test.cs
@@ -51,7 +51,7 @@ public class TestUnicode
 		{
 			var got = token;
 			var expected = Encoding.UTF8.GetString(test.expected[i]);
-			Assert.That(got.SequenceEqual(expected), $"{test.comment}");
+			Assert.That(got.SequenceEqual(expected.AsSpan()), $"{test.comment}");
 			i++;
 		}
 	}
@@ -63,7 +63,7 @@ public class TestUnicode
 		{
 			var got = token;
 			var expected = Encoding.UTF8.GetString(test.expected[i]);
-			Assert.That(got.SequenceEqual(expected), $"{test.comment}");
+			Assert.That(got.SequenceEqual(expected.AsSpan()), $"{test.comment}");
 			i++;
 		}
 	}
@@ -99,7 +99,7 @@ public class TestUnicode
 			var tokens = method(invalidUtf8Bytes);
 			foreach (var token in tokens)
 			{
-				results.AddRange(token);
+				results.AddRange(token.ToArray());
 			}
 
 			Assert.That(results.SequenceEqual(invalidUtf8Bytes));
@@ -119,7 +119,7 @@ public class TestUnicode
 			var tokens = method(invalidChars);
 			foreach (var token in tokens)
 			{
-				results.AddRange(token);
+				results.AddRange(token.ToArray());
 			}
 
 			Assert.That(results.SequenceEqual(invalidChars));
@@ -139,7 +139,7 @@ public class TestUnicode
 					var results = new List<byte>();
 					foreach (var token in tokens)
 					{
-						results.AddRange(token);
+						results.AddRange(token.ToArray());
 					}
 					Assert.That(results.SequenceEqual(bytes));
 				}
@@ -153,7 +153,7 @@ public class TestUnicode
 				var results = new List<char>();
 				foreach (var token in tokens)
 				{
-					results.AddRange(token);
+					results.AddRange(token.ToArray());
 				}
 				Assert.That(results.SequenceEqual(s));
 			}

--- a/Tests/Words.Test.cs
+++ b/Tests/Words.Test.cs
@@ -20,7 +20,7 @@ public class WordsTests
 	public void String(UnicodeTest test)
 	{
 		var s = Encoding.UTF8.GetString(test.input);
-		var tokens = Split.Words(s);
+		var tokens = Split.Words(s.AsSpan());
 		TestUnicode.TestChars(tokens, test);
 	}
 

--- a/uax29/Extensions/Extensions.Graphemes.cs
+++ b/uax29/Extensions/Extensions.Graphemes.cs
@@ -55,7 +55,7 @@ public static partial class Extensions
     /// <returns>
     /// An enumerator of graphemes. Use foreach (var grapheme in graphemes).
     /// </returns>
-    public static SplitEnumerator<char> SplitGraphemes(this string input) => Split.Graphemes(input);
+    public static SplitEnumerator<char> SplitGraphemes(this string input) => Split.Graphemes(input.AsSpan());
 
     /// <summary>
     /// Split the graphemes in the given string.

--- a/uax29/Extensions/Extensions.Sentences.cs
+++ b/uax29/Extensions/Extensions.Sentences.cs
@@ -55,7 +55,7 @@ public static partial class Extensions
     /// <returns>
     /// An enumerator of graphemes. Use foreach (var grapheme in graphemes).
     /// </returns>
-    public static SplitEnumerator<char> SplitSentences(this string input) => Split.Sentences(input);
+    public static SplitEnumerator<char> SplitSentences(this string input) => Split.Sentences(input.AsSpan());
 
     /// <summary>
     /// Split the graphemes in the given string.

--- a/uax29/Extensions/Extensions.Words.cs
+++ b/uax29/Extensions/Extensions.Words.cs
@@ -55,7 +55,7 @@ public static partial class Extensions
     /// <returns>
     /// An enumerator of words. Use foreach (var word in words).
     /// </returns>
-    public static SplitEnumerator<char> SplitWords(this string input, Options options = Options.None) => Split.Words(input, options);
+    public static SplitEnumerator<char> SplitWords(this string input, Options options = Options.None) => Split.Words(input.AsSpan(), options);
 
     /// <summary>
     /// Split the words in the given string.

--- a/uax29/uax29.csproj
+++ b/uax29/uax29.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <PackageId>UAX29</PackageId>
     <Version>3.0.0</Version>
     <Authors>clipperhouse</Authors>
@@ -28,5 +28,11 @@
   <ItemGroup>
     <Folder Include="Legacy/" />
     <Folder Include="Extensions/" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.8" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))" />
+	<PackageReference Include="Shim.System.Text.Rune" Version="6.0.2" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.0'))" />
+	<PackageReference Include="System.Collections.Immutable" Version="9.0.8" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi!

Thank you for building this library.
Since .NET pre-5.0 does not properly support Unicode grapheme clustering, use of this library might be beneficial for people that are stuck on legacy frameworks like 4.x. After checking I've seen that it can be modified with minimal effort both right now and WRT future support and updates.

Summary of the proposed changes:
- tune `LangVersion` only for legacy TFMs to allow using NRTs
- added a few shim libraries for legacy TFMs, each with specific target so they do not pollute the modern .NET builds (I might suggest adding `S.C.Immutable` unconditionally for some quirky dependency scenarios, but this is out of the scope of this PR)
- add `net462` TFM to the library project
- explicitly call `AsSpan` in the library code where `Microsoft.Bcl.Memory` shim doesn't help (extensions), this should not introduce any performance regressions and/or functionality changes
- add `net462` TFM to the tests project
- explicitly call `AsSpan`, `ToArray` and some `Range` methods in the tests code where needed (extensions), this should not introduce any functionality changes
